### PR TITLE
Add unfilled prop and new warning color to progress bar

### DIFF
--- a/packages/riipen-ui-docs/src/pages/components/progress-bar/Colors.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/progress-bar/Colors.jsx
@@ -10,6 +10,7 @@ export default function Colors() {
       <ProgressBar color="tertiary" completion={0.5} />
       <ProgressBar color="positive" completion={0.6} />
       <ProgressBar color="negative" completion={0.7} />
+      <ProgressBar color="warning" completion={0.8} />
     </div>
   );
 }

--- a/packages/riipen-ui-docs/src/pages/components/progress-bar/Unfilled.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/progress-bar/Unfilled.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+import ProgressBar from "@riipen-ui/components/ProgressBar";
+
+export default function Unfilled() {
+  return (
+    <div>
+      <ProgressBar color="primary" unfilled="light" completion={0.3} />
+      <ProgressBar color="primary" unfilled="dark" completion={0.3} />
+    </div>
+  );
+}

--- a/packages/riipen-ui-docs/src/pages/components/progress-bar/progress-bar.md
+++ b/packages/riipen-ui-docs/src/pages/components/progress-bar/progress-bar.md
@@ -15,3 +15,6 @@ Progress bars can be rendered with different colors for different use cases.
 
 {{"demo": "pages/components/progress-bar/Colors.js"}}
 
+And can have either a light or dark unfilled color
+
+{{"demo": "pages/components/progress-bar/Unfilled.js"}}

--- a/packages/riipen-ui/package.json
+++ b/packages/riipen-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riipen-ui",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "private": false,
   "author": {
     "name": "Riipen",

--- a/packages/riipen-ui/src/components/ProgressBar.jsx
+++ b/packages/riipen-ui/src/components/ProgressBar.jsx
@@ -19,8 +19,11 @@ class ProgressBar extends React.Component {
       "positive",
       "primary",
       "secondary",
-      "tertiary"
+      "tertiary",
+      "warning"
     ]),
+
+    unfilled: PropTypes.oneOf(["light", "dark"]),
 
     /**
      * The percentage of the completion between 0 and 1.
@@ -31,17 +34,18 @@ class ProgressBar extends React.Component {
   static defaultProps = {
     classes: [],
     color: "primary",
-    completion: 0
+    completion: 0,
+    unfilled: "light"
   };
 
   static contextType = ThemeContext;
 
   render() {
-    const { classes, color, completion } = this.props;
+    const { classes, color, completion, unfilled } = this.props;
 
     const theme = this.context;
 
-    const className = clsx(color, classes);
+    const className = clsx(color, unfilled, classes);
 
     return (
       <div>
@@ -50,7 +54,6 @@ class ProgressBar extends React.Component {
           progress {
             -moz-appearance: none;
             -webkit-appearance: none;
-            background: ${theme.palette.background.default};
             border: none;
             border-radius: ${theme.shape.borderRadius.md};
             height: 8px;
@@ -58,7 +61,6 @@ class ProgressBar extends React.Component {
           }
 
           progress::-webkit-progress-bar {
-            background: ${theme.palette.background.default};
             border-radius: ${theme.shape.borderRadius.md};
           }
 
@@ -76,6 +78,22 @@ class ProgressBar extends React.Component {
 
           .primary::-moz-progress-bar {
             background: ${theme.palette.primary.main};
+          }
+
+          .light {
+            background: ${theme.palette.grey[50]};
+          }
+
+          .light::-webkit-progress-bar {
+            background: ${theme.palette.grey[50]};
+          }
+
+          .dark {
+            background: ${theme.palette.grey[300]};
+          }
+
+          .dark::-webkit-progress-bar {
+            background: ${theme.palette.grey[300]};
           }
 
           .secondary::-webkit-progress-value {
@@ -108,6 +126,14 @@ class ProgressBar extends React.Component {
 
           .negative::-moz-progress-bar {
             background: ${theme.palette.negative.main};
+          }
+
+          .warning::-webkit-progress-value {
+            background: ${theme.palette.warning.main};
+          }
+
+          .warning::-moz-progress-bar {
+            background: ${theme.palette.warning.main};
           }
         `}</style>
       </div>


### PR DESCRIPTION
## Description
Add unfilled prop and new warning color to progress bar needed for the new project pages

## Notes
I think i did everything except bump the package version?

## Screenshots
<img width="1029" alt="Screen Shot 2019-12-02 at 4 02 15 PM" src="https://user-images.githubusercontent.com/1365762/70005074-28be0c80-151d-11ea-9448-f1ca092b6e14.png">
<img width="1006" alt="Screen Shot 2019-12-02 at 4 02 26 PM" src="https://user-images.githubusercontent.com/1365762/70005075-28be0c80-151d-11ea-8f64-a39e6f525c63.png">
