### PR TITLE
Added flex-grow option to ui grid

### DIFF
--- a/packages/riipen-ui-docs/src/pages/components-api/grid-item.md
+++ b/packages/riipen-ui-docs/src/pages/components-api/grid-item.md
@@ -26,6 +26,7 @@ You can learn more about the difference by [reading this guide](/guides/bundle-s
 | <span class="prop-name">md</span> | <span class="prop-type">number<br>&#124;&nbsp;string</span> |  | The columns use at the medium resolution. Can also be 'hidden'. |
 | <span class="prop-name">sm</span> | <span class="prop-type">number<br>&#124;&nbsp;string</span> |  | The columns use at the small resolution. Can also be 'hidden'. |
 | <span class="prop-name">spacing</span> | <span class="prop-type">0<br>&#124;&nbsp;1<br>&#124;&nbsp;2<br>&#124;&nbsp;3<br>&#124;&nbsp;4<br>&#124;&nbsp;5<br>&#124;&nbsp;6<br>&#124;&nbsp;7<br>&#124;&nbsp;8<br>&#124;&nbsp;9<br>&#124;&nbsp;10</span> | <span class="prop-default">3</span> | Defines the space between this grid item and other items. |
+| <span class="prop-name">flexGrow</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Defines if the grid item should grow to fill extra space in the row |
 
 
 Any other props supplied will be provided to the root element.

--- a/packages/riipen-ui-docs/src/pages/components/form/Basic.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/form/Basic.jsx
@@ -1,12 +1,12 @@
 import React from "react";
 
 import Form from "@riipen-ui/components/Form";
-import TextField from "@riipen-ui/components/TextField";
+import Input from "@riipen-ui/components/Input";
 
 export default function Basic() {
   return (
     <Form>
-      <TextField id="name" label="Name" hint="Your first and last names." />
+      <Input id="name" label="Name" hint="Your first and last names." />
     </Form>
   );
 }

--- a/packages/riipen-ui-docs/src/pages/components/form/Error.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/form/Error.jsx
@@ -1,12 +1,12 @@
 import React from "react";
 
 import Form from "@riipen-ui/components/Form";
-import TextField from "@riipen-ui/components/TextField";
+import Input from "@riipen-ui/components/Input";
 
 export default function Basic() {
   return (
     <Form error="Please provide a name">
-      <TextField id="name" label="Name" hint="Your first and last names." />
+      <Input id="name" label="Name" hint="Your first and last names." />
     </Form>
   );
 }

--- a/packages/riipen-ui-docs/src/pages/components/form/Group.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/form/Group.jsx
@@ -2,13 +2,13 @@ import React from "react";
 
 import Form from "@riipen-ui/components/Form";
 import FormGroup from "@riipen-ui/components/FormGroup";
-import TextField from "@riipen-ui/components/TextField";
+import Input from "@riipen-ui/components/Input";
 
 export default function Group() {
   return (
     <Form>
       <FormGroup title="Basic information">
-        <TextField
+        <Input
           id="name"
           label="Name"
           hint="Your first and last names."
@@ -19,7 +19,7 @@ export default function Group() {
         title="Extra information"
         subtitle="All these fields are optional."
       >
-        <TextField id="biography" label="Biography" multiline />
+        <Input id="biography" label="Biography" multiline />
       </FormGroup>
     </Form>
   );

--- a/packages/riipen-ui-docs/src/pages/components/grid/Grow.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/grid/Grow.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+import Grid from "@riipen-ui/components/Grid";
+import GridItem from "@riipen-ui/components/GridItem";
+
+export default function GrowingGrid() {
+  const itemStyle = {
+    backgroundColor: "#fff",
+    boxShadow: "0 1px 3px 0 rgba(0, 0, 0, 0.23)",
+    padding: "10px",
+    textAlign: "center"
+  };
+
+  return (
+    <Grid>
+      <GridItem lg={3}>
+        <div style={itemStyle}>lg=3</div>
+      </GridItem>
+      <GridItem lg={2} flexGrow>
+        <div style={itemStyle}>lg=2 Grow</div>
+      </GridItem>
+      <GridItem lg={2} flexGrow>
+        <div style={itemStyle}>lg=2 Grow</div>
+      </GridItem>
+      <GridItem lg={6}>
+        <div style={itemStyle}>lg=6</div>
+      </GridItem>
+      <GridItem lg={4} flexGrow>
+        <div style={itemStyle}>lg=4 Grow</div>
+      </GridItem>
+    </Grid>
+  );
+}

--- a/packages/riipen-ui-docs/src/pages/components/grid/grid.md
+++ b/packages/riipen-ui-docs/src/pages/components/grid/grid.md
@@ -41,3 +41,10 @@ this spacing by passing in a spacing factor size which makes the spacing between
 smaller.
 
 {{"demo": "pages/components/grid/Spacing.js"}}
+
+
+### Growing grid items
+Grid items can grow to fill the space remaining in the grid relative to other grid items. Extra space is 
+split between growing grid items that end up in the same row 
+
+{{"demo": "pages/components/grid/Grow.js"}}

--- a/packages/riipen-ui/package.json
+++ b/packages/riipen-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riipen-ui",
-  "version": "0.0.47",
+  "version": "0.0.48",
   "private": false,
   "author": {
     "name": "Riipen",

--- a/packages/riipen-ui/src/components/GridItem.jsx
+++ b/packages/riipen-ui/src/components/GridItem.jsx
@@ -20,6 +20,11 @@ class GridItem extends React.Component {
     classes: PropTypes.array,
 
     /**
+     * Defines if the grid item should grow to fill extra space in the row
+     */
+    flexGrow: PropTypes.bool,
+
+    /**
      * The columns use at the large resolution. Can also be 'hidden'.
      */
     lg: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
@@ -37,12 +42,7 @@ class GridItem extends React.Component {
     /**
      * Defines the space between this grid item and other items.
      */
-    spacing: PropTypes.oneOf(SPACINGS),
-
-    /**
-     * Defines if the grid item should grow to fill extra space in the row
-     */
-    flexGrow: PropTypes.bool
+    spacing: PropTypes.oneOf(SPACINGS)
   };
 
   static defaultProps = {

--- a/packages/riipen-ui/src/components/GridItem.jsx
+++ b/packages/riipen-ui/src/components/GridItem.jsx
@@ -37,23 +37,32 @@ class GridItem extends React.Component {
     /**
      * Defines the space between this grid item and other items.
      */
-    spacing: PropTypes.oneOf(SPACINGS)
+    spacing: PropTypes.oneOf(SPACINGS),
+
+    /**
+     * Defines if the grid item should grow to fill extra space in the row
+     */
+    flexGrow: PropTypes.bool
   };
 
   static defaultProps = {
     classes: [],
     lg: 12,
-    spacing: 3
+    spacing: 3,
+    flexGrow: false,
+    flexShrink: false
   };
 
   static contextType = ThemeContext;
 
   render() {
-    const { children, classes, lg, md, sm, spacing } = this.props;
+    const { children, classes, lg, md, sm, spacing, flexGrow } = this.props;
 
     const theme = this.context;
 
     const className = clsx(classes);
+
+    const grow = flexGrow ? 1 : 0;
 
     return (
       <React.Fragment>
@@ -63,18 +72,18 @@ class GridItem extends React.Component {
             box-sizing: border-box;
             margin-bottom: ${theme.spacing(spacing)}px;
             padding-left: ${theme.spacing(spacing)}px;
-            width: ${(+lg / COLUMNS) * 100 || 0}%;
+            flex: ${grow} 0 ${(+lg / COLUMNS) * 100 || 0}%;
           }
           @media (max-width: ${theme.breakpoints.md}px) {
             div {
               display: ${md === "hidden" ? "none" : "initial"};
-              width: ${((+md || +lg) / COLUMNS) * 100 || 0}%;
+              flex: ${grow} 0 ${((+md || +lg) / COLUMNS) * 100 || 0}%;
             }
           }
           @media (max-width: ${theme.breakpoints.sm}px) {
             div {
               display: ${[sm, md].includes("hidden") ? "none" : "initial"};
-              width: ${((+sm || +md || +lg) / COLUMNS) * 100 || 0}%;
+              flex: ${grow} 0 ${((+sm || +md || +lg) / COLUMNS) * 100 || 0}%;
             }
           }
         `}</style>

--- a/packages/riipen-ui/src/components/GridItem.jsx
+++ b/packages/riipen-ui/src/components/GridItem.jsx
@@ -49,8 +49,7 @@ class GridItem extends React.Component {
     classes: [],
     lg: 12,
     spacing: 3,
-    flexGrow: false,
-    flexShrink: false
+    flexGrow: false
   };
 
   static contextType = ThemeContext;


### PR DESCRIPTION
## Description
Added Grid-Item with grow option to allow grid items to fill the full width of the grid.

## Notes
Also fixed compilation error on forms

## Where to start
packages/riipen-ui/src/components/GridItem.jsx