### PR TITLE
Popover fix

### DIFF
--- a/packages/riipen-ui-docs/src/pages/components-api/menu.md
+++ b/packages/riipen-ui-docs/src/pages/components-api/menu.md
@@ -28,6 +28,7 @@ You can learn more about the difference by [reading this guide](/guides/bundle-s
 | <span class="prop-name">closeOnClick</span> | <span class="prop-type">bool</span> | <span class="prop-default">true</span> | Whether or not the menu should close when an option is chosen with a click event |
 | <span class="prop-name">color</span> | <span class="prop-type">"primary"<br>&#124;&nbsp;"secondary"</span> | <span class="prop-default">"primary"</span> | The color of the component. It supports those theme colors that make sense for this component. |
 | <span class="prop-name">contentPosition</span> | <span class="prop-type">object</span> |  | The location to attach the anchor to on the content element |
+| <span class="prop-name">isOpen</span> | <span class="prop-type">bool</span> | <span class="prop-default">true</span> | Whether or not the menu should be rendered |
 | <span class="prop-name">keepOnScreen</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Whether or not the popout should be forced to stay on screen |
 | <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |  | The function callback for when the selection is changed |
 | <span class="prop-name">onClose</span> | <span class="prop-type">func</span> |  | The function callback to use when the menu closes |

--- a/packages/riipen-ui-docs/src/pages/components-api/popover.md
+++ b/packages/riipen-ui-docs/src/pages/components-api/popover.md
@@ -26,11 +26,11 @@ You can learn more about the difference by [reading this guide](/guides/bundle-s
 | <span class="prop-name">classes</span> | <span class="prop-type">array</span> |  | Array of additional CSS classes to use. |
 | <span class="prop-name">component</span> | <span class="prop-type">string</span> | <span class="prop-default">"span"</span> | The type of element to use at the root |
 | <span class="prop-name">contentPosition</span> | <span class="prop-type">object</span> |  | The location to attach the anchor to on the content element |
+| <span class="prop-name">isOpen</span> | <span class="prop-type">bool</span> | <span class="prop-default">true</span> | Whether the popover should be displayed |
 | <span class="prop-name">keepOnScreen</span> | <span class="prop-type">bool</span> |  | Whether to keep the popout on screen when the anchor element scrolls off |
 | <span class="prop-name">lockScroll</span> | <span class="prop-type">bool</span> | <span class="prop-default">true</span> | Whether to lock the scrollbar when the popover is open |
 | <span class="prop-name">marginThreshold</span> | <span class="prop-type">number</span> | <span class="prop-default">16</span> | The marigins of the page the popover should respect |
 | <span class="prop-name">onClose</span> | <span class="prop-type">func</span> |  | Function call to handle clickaway/ close events, if not provided the anchor element must be removed to clear the popover or use isOpen |
-| <span class="prop-name">open</span> | <span class="prop-type">bool</span> | <span class="prop-default">true</span> | Whether the popover should be displayed |
 | <span class="prop-name">styles</span> | <span class="prop-type">object</span> | <span class="prop-default">{}</span> | Styles to apply to the component |
 
 

--- a/packages/riipen-ui-docs/src/pages/components/popover/Demo.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/popover/Demo.jsx
@@ -8,7 +8,7 @@ import Form from "@riipen-ui/components/Form";
 
 export default function Simple() {
   const anchorEl = React.useRef(null);
-  const [open, setOpen] = React.useState(false);
+  const [isOpen, setIsOpen] = React.useState(false);
   const [anchorPosition, setAnchorPosition] = React.useState({
     vertical: "top",
     horizontal: "left"
@@ -19,7 +19,7 @@ export default function Simple() {
   });
 
   const buttonClick = () => {
-    setOpen(prevVal => !prevVal);
+    setIsOpen(prevVal => !prevVal);
   };
 
   const handleAnchorVertical = (e, value) => {
@@ -141,7 +141,9 @@ export default function Simple() {
                 checked={contentPosition.horizontal === "right"}
               />
             </RadioGroup>
-            <Button onClick={buttonClick}>Open Popover</Button>
+            <Button color="primary" variant="outlined" onClick={buttonClick}>
+              Toggle Popover
+            </Button>
           </Form>
         </div>
         <div className="half" ref={anchorEl}>
@@ -150,7 +152,7 @@ export default function Simple() {
         <Popover
           anchorPosition={anchorPosition}
           contentPosition={contentPosition}
-          open={open}
+          isOpen={isOpen}
           lockScroll={false}
           anchorEl={anchorEl.current}
         >

--- a/packages/riipen-ui/package.json
+++ b/packages/riipen-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riipen-ui",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "private": false,
   "author": {
     "name": "Riipen",

--- a/packages/riipen-ui/package.json
+++ b/packages/riipen-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riipen-ui",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "private": false,
   "author": {
     "name": "Riipen",

--- a/packages/riipen-ui/src/components/Menu.jsx
+++ b/packages/riipen-ui/src/components/Menu.jsx
@@ -48,6 +48,11 @@ class Menu extends React.Component {
     contentPosition: PropTypes.object,
 
     /**
+     * Whether or not the menu should be rendered
+     */
+    isOpen: PropTypes.bool,
+
+    /**
      * Whether or not the popout should be forced to stay on screen
      */
     keepOnScreen: PropTypes.bool,
@@ -83,6 +88,7 @@ class Menu extends React.Component {
     color: "primary",
     classes: [],
     closeOnClick: true,
+    isOpen: true,
     keepOnScreen: false,
     popoverStyles: {},
     variant: "menu"
@@ -110,7 +116,6 @@ class Menu extends React.Component {
 
   handleClose = () => {
     const { onClose } = this.props;
-    this.anchorEl = null;
     if (onClose) onClose();
   };
 
@@ -136,6 +141,7 @@ class Menu extends React.Component {
       children,
       contentPosition,
       keepOnScreen,
+      isOpen,
       popoverStyles,
       selectedIndex,
       variant
@@ -148,7 +154,7 @@ class Menu extends React.Component {
           anchorPosition={anchorPosition}
           contentPosition={contentPosition}
           lockScroll={false}
-          open={Boolean(anchorEl)}
+          isOpen={isOpen}
           anchorEl={anchorEl}
           styles={popoverStyles}
           keepOnScreen={keepOnScreen}

--- a/packages/riipen-ui/src/components/MenuList.jsx
+++ b/packages/riipen-ui/src/components/MenuList.jsx
@@ -155,18 +155,11 @@ class MenuList extends React.Component {
   render() {
     const { children, classes, selectedIndex } = this.props;
 
-    const theme = this.context;
-
     return (
       <React.Fragment>
         <div className={clsx(classes)}>
           {this.getListItems(children, selectedIndex)}
         </div>
-        <style jsx>{`
-          div {
-            margin: ${theme.spacing(1)}px 0;
-          }
-        `}</style>
       </React.Fragment>
     );
   }

--- a/packages/riipen-ui/src/components/Popover.jsx
+++ b/packages/riipen-ui/src/components/Popover.jsx
@@ -46,6 +46,11 @@ class Popover extends React.Component {
     contentPosition: PropTypes.object,
 
     /**
+     * Whether the popover should be displayed
+     */
+    isOpen: PropTypes.bool,
+
+    /**
      * Whether to keep the popout on screen when the anchor element scrolls off
      */
     keepOnScreen: PropTypes.bool,
@@ -67,11 +72,6 @@ class Popover extends React.Component {
     onClose: PropTypes.func,
 
     /**
-     * Whether the popover should be displayed
-     */
-    open: PropTypes.bool,
-
-    /**
      * Styles to apply to the component
      */
     styles: PropTypes.object
@@ -79,9 +79,9 @@ class Popover extends React.Component {
 
   static defaultProps = {
     component: "span",
+    isOpen: true,
     lockScroll: true,
     marginThreshold: 16,
-    open: true,
     styles: {}
   };
 
@@ -114,13 +114,13 @@ class Popover extends React.Component {
       this.lockParentScroll();
     }
 
-    this.getPositioningStyle();
+    this.setPositioningStyle();
   }
 
   componentDidUpdate(prevProps) {
     const anchorChange =
       prevProps.anchorEl === null && this.props.anchorEl !== null;
-    const openChange = !prevProps.open && this.props.open;
+    const openChange = !prevProps.isOpen && this.props.isOpen;
     const anchorPositionChange = !(
       prevProps.anchorPosition === this.props.anchorPosition
     );
@@ -134,7 +134,7 @@ class Popover extends React.Component {
       contentPositionChange ||
       anchorPositionChange
     ) {
-      this.getPositioningStyle();
+      this.setPositioningStyle();
     }
   }
 
@@ -155,7 +155,7 @@ class Popover extends React.Component {
     return typeof anchorEl === "function" ? anchorEl() : anchorEl;
   };
 
-  getPositioningStyle = () => {
+  setPositioningStyle = () => {
     const contentRef = this.contentRef.current;
     const {
       anchorPosition = {
@@ -250,9 +250,9 @@ class Popover extends React.Component {
   }
 
   handleCloseEvent = event => {
-    const { open, anchorEl } = this.props;
+    const { isOpen, anchorEl } = this.props;
     const contentRef = this.contentRef.current;
-    if (!contentRef || !open) return;
+    if (!contentRef || !isOpen) return;
     if (event.type === "mousedown") {
       // Check if mouse click happened inside popover
       // Or on the anchorEl
@@ -298,20 +298,27 @@ class Popover extends React.Component {
 
   updatePosition = () => {
     if (!this.props.anchorEl) return undefined;
-    return this.getPositioningStyle();
+    return this.setPositioningStyle();
   };
 
   static contextType = ThemeContext;
 
   render() {
-    const { anchorEl, classes, children, component, styles, open } = this.props;
+    const {
+      anchorEl,
+      classes,
+      children,
+      component,
+      styles,
+      isOpen
+    } = this.props;
     const theme = this.context;
-    const className = clsx(classes, "popover", { open });
+    const className = clsx(classes, "popover", { open: isOpen });
     const Component = component;
 
     return (
       <React.Fragment>
-        {anchorEl && open && (
+        {anchorEl && isOpen && (
           <Component
             style={{ ...styles, ...this.state.contentStyles }}
             ref={this.contentRef}


### PR DESCRIPTION
## Description
Updated the popover for the menu to be rendered as hidden in the top left corner until it is opened. 
This fixes the issue where the popover would not be in the correct position if it was initially positioned too far to the right of the screen

## Notes
Turns out position: absolute combined with top and left attributes is 'smart' enough to make sure the width of the box is not more than the width of the view window. So I have positioned the box in the top left to start and then move it to the correct location when the popover is opened.

