### PR TITLE
Add withClasses HOC to all components

### DIFF
--- a/packages/riipen-ui/src/components/AppBar.jsx
+++ b/packages/riipen-ui/src/components/AppBar.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import ThemeContext from "../styles/ThemeContext";
+import withClasses from "../utils/withClasses";
 
 class AppBar extends React.Component {
   static propTypes = {
@@ -47,7 +48,7 @@ class AppBar extends React.Component {
 
     const theme = this.context;
 
-    const className = clsx(color, position, classes);
+    const className = clsx(classes, color, position);
 
     return (
       <React.Fragment>
@@ -110,4 +111,4 @@ class AppBar extends React.Component {
   }
 }
 
-export default AppBar;
+export default withClasses()(AppBar);

--- a/packages/riipen-ui/src/components/Avatar.jsx
+++ b/packages/riipen-ui/src/components/Avatar.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import ThemeContext from "../styles/ThemeContext";
+import withClasses from "../utils/withClasses";
 
 class Avatar extends React.Component {
   static propTypes = {
@@ -105,4 +106,4 @@ class Avatar extends React.Component {
   }
 }
 
-export default Avatar;
+export default withClasses()(Avatar);

--- a/packages/riipen-ui/src/components/Backdrop.jsx
+++ b/packages/riipen-ui/src/components/Backdrop.jsx
@@ -2,6 +2,8 @@ import clsx from "clsx";
 import PropTypes from "prop-types";
 import React from "react";
 
+import withClasses from "../utils/withClasses";
+
 class Backdrop extends React.Component {
   static propTypes = {
     /**
@@ -52,4 +54,4 @@ class Backdrop extends React.Component {
   }
 }
 
-export default Backdrop;
+export default withClasses()(Backdrop);

--- a/packages/riipen-ui/src/components/Badge.jsx
+++ b/packages/riipen-ui/src/components/Badge.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import ThemeContext from "../styles/ThemeContext";
+import withClasses from "../utils/withClasses";
 
 const RADIUS_STANDARD = 10;
 const RADIUS_DOT = 5;
@@ -227,4 +228,4 @@ class Badge extends React.Component {
   }
 }
 
-export default Badge;
+export default withClasses()(Badge);

--- a/packages/riipen-ui/src/components/Banner.jsx
+++ b/packages/riipen-ui/src/components/Banner.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import ThemeContext from "../styles/ThemeContext";
+import withClasses from "../utils/withClasses";
 
 class Banner extends React.Component {
   static propTypes = {
@@ -94,4 +95,4 @@ class Banner extends React.Component {
   }
 }
 
-export default Banner;
+export default withClasses()(Banner);

--- a/packages/riipen-ui/src/components/Breadcrumbs.jsx
+++ b/packages/riipen-ui/src/components/Breadcrumbs.jsx
@@ -2,6 +2,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import ThemeContext from "../styles/ThemeContext";
+import withClasses from "../utils/withClasses";
 
 import Typography from "./Typography";
 
@@ -80,4 +81,4 @@ class Breadcrumbs extends React.Component {
   }
 }
 
-export default Breadcrumbs;
+export default withClasses()(Breadcrumbs);

--- a/packages/riipen-ui/src/components/Button.jsx
+++ b/packages/riipen-ui/src/components/Button.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import ThemeContext from "../styles/ThemeContext";
+import withClasses from "../utils/withClasses";
 
 class Button extends React.Component {
   static propTypes = {
@@ -355,4 +356,4 @@ class Button extends React.Component {
   }
 }
 
-export default Button;
+export default withClasses()(Button);

--- a/packages/riipen-ui/src/components/ButtonIcon.jsx
+++ b/packages/riipen-ui/src/components/ButtonIcon.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import ThemeContext from "../styles/ThemeContext";
+import withClasses from "../utils/withClasses";
 
 class ButtonIcon extends React.Component {
   static propTypes = {
@@ -184,4 +185,4 @@ class ButtonIcon extends React.Component {
   }
 }
 
-export default ButtonIcon;
+export default withClasses()(ButtonIcon);

--- a/packages/riipen-ui/src/components/Checkbox.jsx
+++ b/packages/riipen-ui/src/components/Checkbox.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import ThemeContext from "../styles/ThemeContext";
+import withClasses from "../utils/withClasses";
 
 import Typography from "./Typography";
 
@@ -198,4 +199,4 @@ class Checkbox extends React.Component {
   }
 }
 
-export default Checkbox;
+export default withClasses()(Checkbox);

--- a/packages/riipen-ui/src/components/Chip.jsx
+++ b/packages/riipen-ui/src/components/Chip.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import ThemeContext from "../styles/ThemeContext";
+import withClasses from "../utils/withClasses";
 
 class Chip extends React.Component {
   static propTypes = {
@@ -266,4 +267,4 @@ class Chip extends React.Component {
   }
 }
 
-export default Chip;
+export default withClasses()(Chip);

--- a/packages/riipen-ui/src/components/ClickAway.jsx
+++ b/packages/riipen-ui/src/components/ClickAway.jsx
@@ -2,6 +2,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import ThemeContext from "../styles/ThemeContext";
+import withClasses from "../utils/withClasses";
 
 class ClickAway extends React.Component {
   static propTypes = {
@@ -58,4 +59,4 @@ class ClickAway extends React.Component {
   }
 }
 
-export default ClickAway;
+export default withClasses()(ClickAway);

--- a/packages/riipen-ui/src/components/Container.jsx
+++ b/packages/riipen-ui/src/components/Container.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import ThemeContext from "../styles/ThemeContext";
+import withClasses from "../utils/withClasses";
 
 class Container extends React.Component {
   static propTypes = {
@@ -68,4 +69,4 @@ class Container extends React.Component {
   }
 }
 
-export default Container;
+export default withClasses()(Container);

--- a/packages/riipen-ui/src/components/Divider.jsx
+++ b/packages/riipen-ui/src/components/Divider.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import ThemeContext from "../styles/ThemeContext";
+import withClasses from "../utils/withClasses";
 
 class Divider extends React.Component {
   static propTypes = {
@@ -50,4 +51,4 @@ class Divider extends React.Component {
   }
 }
 
-export default Divider;
+export default withClasses()(Divider);

--- a/packages/riipen-ui/src/components/Drawer.jsx
+++ b/packages/riipen-ui/src/components/Drawer.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import ThemeContext from "../styles/ThemeContext";
+import withClasses from "../utils/withClasses";
 
 import Backdrop from "./Backdrop";
 import ClickAway from "./ClickAway";
@@ -102,4 +103,4 @@ class Drawer extends React.Component {
   }
 }
 
-export default Drawer;
+export default withClasses()(Drawer);

--- a/packages/riipen-ui/src/components/Form.jsx
+++ b/packages/riipen-ui/src/components/Form.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import ThemeContext from "../styles/ThemeContext";
+import withClasses from "../utils/withClasses";
 
 import Notice from "./Notice";
 import Typography from "./Typography";
@@ -138,4 +139,4 @@ class Form extends React.Component {
   }
 }
 
-export default Form;
+export default withClasses()(Form);

--- a/packages/riipen-ui/src/components/FormGroup.jsx
+++ b/packages/riipen-ui/src/components/FormGroup.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import ThemeContext from "../styles/ThemeContext";
+import withClasses from "../utils/withClasses";
 
 import Typography from "./Typography";
 
@@ -77,4 +78,4 @@ class FormGroup extends React.Component {
   }
 }
 
-export default FormGroup;
+export default withClasses()(FormGroup);

--- a/packages/riipen-ui/src/components/Grid.jsx
+++ b/packages/riipen-ui/src/components/Grid.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import ThemeContext from "../styles/ThemeContext";
+import withClasses from "../utils/withClasses";
 
 const SPACINGS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
@@ -95,4 +96,4 @@ class Grid extends React.Component {
   }
 }
 
-export default Grid;
+export default withClasses()(Grid);

--- a/packages/riipen-ui/src/components/GridItem.jsx
+++ b/packages/riipen-ui/src/components/GridItem.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import ThemeContext from "../styles/ThemeContext";
+import withClasses from "../utils/withClasses";
 
 const COLUMNS = 12;
 const SPACINGS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
@@ -89,4 +90,4 @@ class GridItem extends React.Component {
   }
 }
 
-export default GridItem;
+export default withClasses()(GridItem);

--- a/packages/riipen-ui/src/components/Hidden.jsx
+++ b/packages/riipen-ui/src/components/Hidden.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import ThemeContext from "../styles/ThemeContext";
+import withClasses from "../utils/withClasses";
 
 class Hidden extends React.Component {
   static propTypes = {
@@ -99,4 +100,4 @@ class Hidden extends React.Component {
   }
 }
 
-export default Hidden;
+export default withClasses()(Hidden);

--- a/packages/riipen-ui/src/components/Input.jsx
+++ b/packages/riipen-ui/src/components/Input.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import ThemeContext from "../styles/ThemeContext";
+import withClasses from "../utils/withClasses";
 
 import InputLabel from "./InputLabel";
 import InputHint from "./InputHint";
@@ -151,4 +152,4 @@ class Input extends React.Component {
   }
 }
 
-export default Input;
+export default withClasses()(Input);

--- a/packages/riipen-ui/src/components/InputHint.jsx
+++ b/packages/riipen-ui/src/components/InputHint.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import ThemeContext from "../styles/ThemeContext";
+import withClasses from "../utils/withClasses";
 
 import Typography from "./Typography";
 
@@ -47,4 +48,4 @@ class InputHint extends React.Component {
   }
 }
 
-export default InputHint;
+export default withClasses()(InputHint);

--- a/packages/riipen-ui/src/components/InputLabel.jsx
+++ b/packages/riipen-ui/src/components/InputLabel.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import ThemeContext from "../styles/ThemeContext";
+import withClasses from "../utils/withClasses";
 
 import Typography from "./Typography";
 
@@ -57,4 +58,4 @@ class InputLabel extends React.Component {
   }
 }
 
-export default InputLabel;
+export default withClasses(InputLabel);

--- a/packages/riipen-ui/src/components/Link.jsx
+++ b/packages/riipen-ui/src/components/Link.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import ThemeContext from "../styles/ThemeContext";
+import withClasses from "../utils/withClasses";
 
 class Link extends React.Component {
   static propTypes = {
@@ -144,4 +145,4 @@ class Link extends React.Component {
   }
 }
 
-export default Link;
+export default withClasses()(Link);

--- a/packages/riipen-ui/src/components/List.jsx
+++ b/packages/riipen-ui/src/components/List.jsx
@@ -2,6 +2,8 @@ import clsx from "clsx";
 import PropTypes from "prop-types";
 import React from "react";
 
+import withClasses from "../utils/withClasses";
+
 class List extends React.Component {
   static propTypes = {
     /**
@@ -39,4 +41,4 @@ class List extends React.Component {
   }
 }
 
-export default List;
+export default withClasses()(List);

--- a/packages/riipen-ui/src/components/ListItem.jsx
+++ b/packages/riipen-ui/src/components/ListItem.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import ThemeContext from "../styles/ThemeContext";
+import withClasses from "../utils/withClasses";
 
 class ListItem extends React.Component {
   static propTypes = {
@@ -65,4 +66,4 @@ class ListItem extends React.Component {
   }
 }
 
-export default ListItem;
+export default withClasses()(ListItem);

--- a/packages/riipen-ui/src/components/Menu.jsx
+++ b/packages/riipen-ui/src/components/Menu.jsx
@@ -2,6 +2,8 @@ import React from "react";
 
 import PropTypes from "prop-types";
 
+import withClasses from "../utils/withClasses";
+
 import MenuList from "./MenuList";
 import Popover from "./Popover";
 
@@ -173,4 +175,4 @@ class Menu extends React.Component {
   }
 }
 
-export default Menu;
+export default withClasses()(Menu);

--- a/packages/riipen-ui/src/components/MenuItem.jsx
+++ b/packages/riipen-ui/src/components/MenuItem.jsx
@@ -5,6 +5,7 @@ import clsx from "clsx";
 import css from "styled-jsx/css";
 
 import ThemeContext from "../styles/ThemeContext";
+import withClasses from "../utils/withClasses";
 
 import ListItem from "./ListItem";
 
@@ -148,4 +149,4 @@ class MenuItem extends React.Component {
   }
 }
 
-export default MenuItem;
+export default withClasses()(MenuItem);

--- a/packages/riipen-ui/src/components/MenuList.jsx
+++ b/packages/riipen-ui/src/components/MenuList.jsx
@@ -3,6 +3,7 @@ import React from "react";
 import PropTypes from "prop-types";
 
 import ThemeContext from "../styles/ThemeContext";
+import withClasses from "../utils/withClasses";
 
 class MenuList extends React.Component {
   static propTypes = {
@@ -165,4 +166,4 @@ class MenuList extends React.Component {
   }
 }
 
-export default MenuList;
+export default withClasses()(MenuList);

--- a/packages/riipen-ui/src/components/Notice.jsx
+++ b/packages/riipen-ui/src/components/Notice.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import ThemeContext from "../styles/ThemeContext";
+import withClasses from "../utils/withClasses";
 
 class Notice extends React.Component {
   static propTypes = {
@@ -79,4 +80,4 @@ class Notice extends React.Component {
   }
 }
 
-export default Notice;
+export default withClasses()(Notice);

--- a/packages/riipen-ui/src/components/Popover.jsx
+++ b/packages/riipen-ui/src/components/Popover.jsx
@@ -1,7 +1,6 @@
+import clsx from "clsx";
 import React from "react";
 import PropTypes from "prop-types";
-
-import clsx from "clsx";
 
 import ThemeContext from "../styles/ThemeContext";
 
@@ -12,6 +11,7 @@ import {
   getOffsetTop,
   debounce
 } from "../utils";
+import withClasses from "../utils/withClasses";
 
 class Popover extends React.Component {
   static propTypes = {
@@ -351,4 +351,4 @@ class Popover extends React.Component {
   }
 }
 
-export default Popover;
+export default withClasses()(Popover);

--- a/packages/riipen-ui/src/components/ProgressBar.jsx
+++ b/packages/riipen-ui/src/components/ProgressBar.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import ThemeContext from "../styles/ThemeContext";
+import withClasses from "../utils/withClasses";
 
 class ProgressBar extends React.Component {
   static propTypes = {
@@ -141,4 +142,4 @@ class ProgressBar extends React.Component {
   }
 }
 
-export default ProgressBar;
+export default withClasses()(ProgressBar);

--- a/packages/riipen-ui/src/components/Radio.jsx
+++ b/packages/riipen-ui/src/components/Radio.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import ThemeContext from "../styles/ThemeContext";
+import withClasses from "../utils/withClasses";
 
 import Typography from "./Typography";
 
@@ -138,4 +139,4 @@ class Radio extends React.Component {
   }
 }
 
-export default Radio;
+export default withClasses()(Radio);

--- a/packages/riipen-ui/src/components/RadioGroup.jsx
+++ b/packages/riipen-ui/src/components/RadioGroup.jsx
@@ -1,6 +1,8 @@
 import PropTypes from "prop-types";
 import React from "react";
 
+import withClasses from "../utils/withClasses";
+
 import InputLabel from "./InputLabel";
 import InputHint from "./InputHint";
 import Typography from "./Typography";
@@ -101,4 +103,4 @@ class RadioGroup extends React.Component {
   }
 }
 
-export default RadioGroup;
+export default withClasses()(RadioGroup);

--- a/packages/riipen-ui/src/components/Tab.jsx
+++ b/packages/riipen-ui/src/components/Tab.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import ThemeContext from "../styles/ThemeContext";
+import withClasses from "../utils/withClasses";
 
 class Tab extends React.Component {
   static propTypes = {
@@ -182,4 +183,4 @@ class Tab extends React.Component {
   }
 }
 
-export default Tab;
+export default withClasses()(Tab);

--- a/packages/riipen-ui/src/components/Tabs.jsx
+++ b/packages/riipen-ui/src/components/Tabs.jsx
@@ -2,6 +2,8 @@ import clsx from "clsx";
 import PropTypes from "prop-types";
 import React from "react";
 
+import withClasses from "../utils/withClasses";
+
 class Tabs extends React.Component {
   static propTypes = {
     /**
@@ -125,4 +127,4 @@ class Tabs extends React.Component {
   }
 }
 
-export default Tabs;
+export default withClasses()(Tabs);

--- a/packages/riipen-ui/src/components/Toolbar.jsx
+++ b/packages/riipen-ui/src/components/Toolbar.jsx
@@ -2,6 +2,8 @@ import clsx from "clsx";
 import PropTypes from "prop-types";
 import React from "react";
 
+import withClasses from "../utils/withClasses";
+
 class Toolbar extends React.Component {
   static propTypes = {
     /**
@@ -39,4 +41,4 @@ class Toolbar extends React.Component {
   }
 }
 
-export default Toolbar;
+export default withClasses()(Toolbar);

--- a/packages/riipen-ui/src/components/Typography.jsx
+++ b/packages/riipen-ui/src/components/Typography.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import ThemeContext from "../styles/ThemeContext";
+import withClasses from "../utils/withClasses";
 
 const variantMapping = {
   h1: "h1",
@@ -261,4 +262,4 @@ class Typography extends React.Component {
   }
 }
 
-export default Typography;
+export default withClasses()(Typography);

--- a/packages/riipen-ui/src/utils/withClasses.jsx
+++ b/packages/riipen-ui/src/utils/withClasses.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import clsx from "clsx";
+import PropTypes from "prop-types";
+
+const withClasses = () => Component => {
+  if (process.env.NODE_ENV !== "production") {
+    if (Component === undefined) {
+      throw new Error(
+        [
+          "You are calling withStyles(styles)(Component) with an undefined component.",
+          "You may have forgotten to import it."
+        ].join("\n")
+      );
+    }
+  }
+
+  const WithClasses = React.forwardRef(function WithClasses(props, ref) {
+    const { classes, ...other } = props;
+    return (
+      <Component ref={ref} classes={[clsx("riipen", classes)]} {...other} />
+    );
+  });
+
+  WithClasses.propTypes = {
+    /**
+     * Extend the styles applied to the component.
+     */
+    classes: PropTypes.object
+  };
+
+  return WithClasses;
+};
+
+export default withClasses;

--- a/packages/riipen-ui/src/utils/withClasses.jsx
+++ b/packages/riipen-ui/src/utils/withClasses.jsx
@@ -1,25 +1,15 @@
 import React from "react";
-import clsx from "clsx";
 import PropTypes from "prop-types";
 
 const withClasses = () => Component => {
-  if (process.env.NODE_ENV !== "production") {
-    if (Component === undefined) {
-      throw new Error(
-        [
-          "You are calling withStyles(styles)(Component) with an undefined component.",
-          "You may have forgotten to import it."
-        ].join("\n")
-      );
-    }
-  }
-
   const WithClasses = React.forwardRef(function WithClasses(props, ref) {
     const { classes, ...other } = props;
-    return (
-      <Component ref={ref} classes={[clsx("riipen", classes)]} {...other} />
-    );
+    return <Component ref={ref} classes={["riipen", ...classes]} {...other} />;
   });
+
+  WithClasses.defaultProps = {
+    classes: []
+  };
 
   WithClasses.propTypes = {
     /**


### PR DESCRIPTION
## Description
The new plan is to include a "riipen" class with all components exposed in the UIKit. 
In order to override styles on the web a class selector like the one below can be used.
:global(.riipen).myNewClass {}
This allows us to override defaults while still making changes to the UI Kit obvious.
The general rule for the UI Kit should be:
” oh, you used :global(.riipen), why was that needed? should something be added to the kit? is it a one off?”

## Notes
I have used a HOC to allow us to add more custom classes using the component name in the future if we deem it necessary.

## Screenshots
![Screen Shot 2020-02-26 at 15 32 54](https://user-images.githubusercontent.com/4382804/75397992-43e6b100-58ad-11ea-977f-a388d4d0972f.png)
<img width="472" alt="Screen Shot 2020-02-26 at 15 33 06" src="https://user-images.githubusercontent.com/4382804/75398002-49dc9200-58ad-11ea-9678-78e893add198.png">


## Where to Start
packages/riipen-ui/src/utils/withClasses.jsx