### PR TITLE
[PLT-4851] Forward Menu onClose prop to Popover

### DIFF
--- a/packages/riipen-ui/src/components/Menu.jsx
+++ b/packages/riipen-ui/src/components/Menu.jsx
@@ -94,15 +94,6 @@ class Menu extends React.Component {
     variant: "menu"
   };
 
-  constructor(props) {
-    super(props);
-    this.handleCloseEvent = this.handleCloseEvent.bind(this);
-  }
-
-  componentDidMount() {
-    window.addEventListener("keydown", this.handleCloseEvent);
-  }
-
   componentDidUpdate() {
     const { anchorEl } = this.props;
     if (document.activeElement && anchorEl) {
@@ -110,28 +101,10 @@ class Menu extends React.Component {
     }
   }
 
-  componentWillUnmount() {
-    window.removeEventListener("keydown", this.handleCloseEvent);
-  }
-
-  handleClose = () => {
-    const { onClose } = this.props;
-    if (onClose) onClose();
-  };
-
   handleChange = (idx, event) => {
     const { onChange, closeOnClick } = this.props;
     if (onChange) onChange(idx, event);
     if (closeOnClick && event && event.type === "click") this.handleClose(idx);
-  };
-
-  handleCloseEvent = event => {
-    const { anchorEl } = this.props;
-    if (!anchorEl) return;
-    if (event.key === "Enter") {
-      event.preventDefault();
-      this.handleClose();
-    }
   };
 
   render() {
@@ -142,6 +115,7 @@ class Menu extends React.Component {
       contentPosition,
       keepOnScreen,
       isOpen,
+      onClose,
       popoverStyles,
       selectedIndex,
       variant
@@ -150,7 +124,7 @@ class Menu extends React.Component {
     return (
       <React.Fragment>
         <Popover
-          onClose={this.handleClose}
+          onClose={onClose}
           anchorPosition={anchorPosition}
           contentPosition={contentPosition}
           lockScroll={false}


### PR DESCRIPTION
https://github.com/riipen/web/pull/2218

## Description
This fixes an issue where hitting enter in a textarea caused it to lose focus. I remove the keydown handler and just pass through the onClose prop 🎉 .

Let me know if there is some case that forwarding onClose to the popover won't cover. I thiiiink this seems good.. but 🤷‍♂ 

## Notes
This bug was so hard to track down, mostly because of its intermittent behaviour. On some pages it happened, and then others it didnt.. wasn't affected by being outside of the react tree.. but messing with the entity reducer could get it to not trigger sometimes (totally by chance). Ultimately when anchorEl was null the bug didn't trigger.

Just happy I eventually found it 🙈 . We should try to be careful about window.addEventListener in the future and possibly try to remove current usages in web and ui wherever possible.