### PR TITLE
[PLT-4906] Menu Children

### DIFF
--- a/packages/riipen-ui-docs/src/pages/components-api/menu-list.md
+++ b/packages/riipen-ui-docs/src/pages/components-api/menu-list.md
@@ -21,7 +21,7 @@ You can learn more about the difference by [reading this guide](/guides/bundle-s
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">autoFocus</span> | <span class="prop-type">bool</span> |  | Wether to select the first element on list open |
-| <span class="prop-name">children</span> | <span class="prop-type">array</span> |  | The content of the component. |
+| <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The content of the component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">array</span> |  | Array of additional CSS classes to use. |
 | <span class="prop-name">color</span> | <span class="prop-type">"primary"<br>&#124;&nbsp;"secondary"</span> |  | The color of the component. It supports those theme colors that make sense for this component. |
 | <span class="prop-name">selectChange</span> | <span class="prop-type">func</span> |  | The function callback when an item is selected |

--- a/packages/riipen-ui-docs/src/pages/components-api/menu.md
+++ b/packages/riipen-ui-docs/src/pages/components-api/menu.md
@@ -23,7 +23,7 @@ You can learn more about the difference by [reading this guide](/guides/bundle-s
 | <span class="prop-name">anchorEl</span> | <span class="prop-type">object</span> |  | The element the menu is attached too |
 | <span class="prop-name">anchorPosition</span> | <span class="prop-type">object</span> |  | The location to attach the content too on the anchor element |
 | <span class="prop-name">autoFocus</span> | <span class="prop-type">bool</span> |  | Whether to autofocus the first element on first open |
-| <span class="prop-name">children</span> | <span class="prop-type">array</span> |  | The content of the component. |
+| <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The content of the component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">array</span> | <span class="prop-default">[]</span> | Array of additional CSS classes to use. |
 | <span class="prop-name">closeOnClick</span> | <span class="prop-type">bool</span> | <span class="prop-default">true</span> | Whether or not the menu should close when an option is chosen with a click event |
 | <span class="prop-name">color</span> | <span class="prop-type">"primary"<br>&#124;&nbsp;"secondary"</span> | <span class="prop-default">"primary"</span> | The color of the component. It supports those theme colors that make sense for this component. |

--- a/packages/riipen-ui/package.json
+++ b/packages/riipen-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riipen-ui",
-  "version": "0.0.72",
+  "version": "0.0.73",
   "private": false,
   "author": {
     "name": "Riipen",

--- a/packages/riipen-ui/src/components/Menu.jsx
+++ b/packages/riipen-ui/src/components/Menu.jsx
@@ -27,7 +27,7 @@ class Menu extends React.Component {
     /**
      * The content of the component.
      */
-    children: PropTypes.array,
+    children: PropTypes.node,
 
     /**
      * Array of additional CSS classes to use.

--- a/packages/riipen-ui/src/components/MenuList.jsx
+++ b/packages/riipen-ui/src/components/MenuList.jsx
@@ -15,7 +15,7 @@ class MenuList extends React.Component {
     /**
      * The content of the component.
      */
-    children: PropTypes.array,
+    children: PropTypes.node,
 
     /**
      * Array of additional CSS classes to use.
@@ -69,7 +69,7 @@ class MenuList extends React.Component {
   getListItems(children, activeItemIndex) {
     const { variant } = this.props;
 
-    return children.map((child, idx) => {
+    return React.Children.map(children, (child, idx) => {
       let newProps = {
         key: idx,
         color: this.props.color


### PR DESCRIPTION
## Description
Added proper handling for children. 
The components used to crash when only 1 child was provided as it is not handled as an array. Using the React.Children.map() works the way it was built to work

## Notes
Might need to update a couple other places, ticket logged to search for those

## Where to Start
packages/riipen-ui/src/components/MenuList.jsx