### PR TITLE
[PLT-4943]: Update input label, form group, and input styling

### DIFF
--- a/packages/riipen-ui/package.json
+++ b/packages/riipen-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riipen-ui",
-  "version": "0.0.72",
+  "version": "0.0.73",
   "private": false,
   "author": {
     "name": "Riipen",

--- a/packages/riipen-ui/package.json
+++ b/packages/riipen-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riipen-ui",
-  "version": "0.0.74",
+  "version": "0.0.75",
   "private": false,
   "author": {
     "name": "Riipen",

--- a/packages/riipen-ui/src/components/FormGroup.jsx
+++ b/packages/riipen-ui/src/components/FormGroup.jsx
@@ -1,4 +1,6 @@
 import clsx from "clsx";
+import css from "styled-jsx/css";
+
 import PropTypes from "prop-types";
 import React from "react";
 
@@ -34,6 +36,23 @@ class FormGroup extends React.Component {
     classes: []
   };
 
+  getLinkedStyles = () => {
+    const theme = this.context;
+
+    return css.resolve`
+      .subtitle {
+        color: ${theme.palette.text.secondary};
+        font-weight: ${theme.typography.fontWeight.regular};
+      }
+
+      .title {
+        font-weight: ${theme.typography.fontWeight.medium};
+        font-size: 22px;
+        margin-bottom: ${theme.spacing(3)}px;
+      }
+    `;
+  };
+
   static contextType = ThemeContext;
 
   render() {
@@ -41,19 +60,31 @@ class FormGroup extends React.Component {
 
     const theme = this.context;
 
+    const linkedStyles = this.getLinkedStyles();
     const className = clsx(classes);
 
     return (
       <React.Fragment>
         <fieldset className={className}>
           {title && (
-            <Typography component="p" gutter variant="h3">
+            <Typography
+              classes={[linkedStyles.className, "title"]}
+              component="p"
+              variant="h3"
+            >
               {title}
+              {linkedStyles.styles}
             </Typography>
           )}
           {subtitle && (
-            <Typography component="p" gutter variant="h4">
+            <Typography
+              classes={[linkedStyles.className, "subtitle"]}
+              component="p"
+              gutter
+              variant="h4"
+            >
               {subtitle}
+              {linkedStyles.styles}
             </Typography>
           )}
           <div className="children">{children}</div>

--- a/packages/riipen-ui/src/components/Input.jsx
+++ b/packages/riipen-ui/src/components/Input.jsx
@@ -122,7 +122,7 @@ class Input extends React.Component {
             font-family: ${theme.typography.fontFamily};
             font-size: 14px;
             outline: none;
-            padding: ${theme.spacing(2)}px;
+            padding: ${theme.spacing(1.5)}px;
             position: relative;
             transition: all ${theme.transitions.duration.standard}ms;
             width: 100%;

--- a/packages/riipen-ui/src/components/Input.jsx
+++ b/packages/riipen-ui/src/components/Input.jsx
@@ -91,7 +91,11 @@ class Input extends React.Component {
     return (
       <div className={className}>
         {label && (
-          <InputLabel htmlFor={other.id || other.name} required={required}>
+          <InputLabel
+            htmlFor={other.id || other.name}
+            required={required}
+            marginBottom={hint ? 1 : 3}
+          >
             {label}
           </InputLabel>
         )}
@@ -120,9 +124,10 @@ class Input extends React.Component {
             box-sizing: border-box;
             color: ${theme.palette.text.primary};
             font-family: ${theme.typography.fontFamily};
-            font-size: 14px;
+            font-size: ${theme.typography.body1.fontSize};
+            line-height: 1;
             outline: none;
-            padding: ${theme.spacing(1.5)}px;
+            padding: ${theme.spacing(2)}px;
             position: relative;
             transition: all ${theme.transitions.duration.standard}ms;
             width: 100%;

--- a/packages/riipen-ui/src/components/InputHint.jsx
+++ b/packages/riipen-ui/src/components/InputHint.jsx
@@ -40,6 +40,7 @@ class InputHint extends React.Component {
         </div>
         <style jsx>{`
           div {
+            color: ${theme.palette.text.secondary};
             margin-bottom: ${theme.spacing(2)}px;
           }
         `}</style>

--- a/packages/riipen-ui/src/components/InputLabel.jsx
+++ b/packages/riipen-ui/src/components/InputLabel.jsx
@@ -20,6 +20,11 @@ class InputLabel extends React.Component {
     classes: PropTypes.array,
 
     /**
+     * Margin bottom styling to apply to the label.
+     */
+    marginBottom: PropTypes.number,
+
+    /**
      * If true, an asterisk will be appended to the end of the label.
      */
     required: PropTypes.bool
@@ -27,13 +32,14 @@ class InputLabel extends React.Component {
 
   static defaultProps = {
     classes: [],
+    marginBottom: 3,
     required: false
   };
 
   static contextType = ThemeContext;
 
   render() {
-    const { children, classes, required, ...other } = this.props;
+    const { children, classes, marginBottom, required, ...other } = this.props;
 
     const theme = this.context;
 
@@ -56,7 +62,7 @@ class InputLabel extends React.Component {
             font-weight: ${theme.typography.body1.fontWeight};
             letter-spacing: ${theme.typography.body1.letterSpacing};
             line-height: 1.4;
-            margin-bottom: ${theme.spacing(3)}px;
+            margin-bottom: ${theme.spacing(marginBottom)}px;
           }
         `}</style>
       </React.Fragment>

--- a/packages/riipen-ui/src/components/InputLabel.jsx
+++ b/packages/riipen-ui/src/components/InputLabel.jsx
@@ -42,15 +42,21 @@ class InputLabel extends React.Component {
     return (
       <React.Fragment>
         <label className={className} {...other}>
-          <Typography>
+          <Typography color="inherit" variant="inherit">
             {children}
             {required && " *"}
           </Typography>
         </label>
         <style jsx>{`
           label {
+            color: ${theme.palette.text.secondary};
             display: inline-block;
-            margin-bottom: ${theme.spacing(1)}px;
+            font-family: ${theme.typography.body1.fontFamily};
+            font-size: font-size: 16px;
+            font-weight: ${theme.typography.body1.fontWeight};
+            letter-spacing: ${theme.typography.body1.letterSpacing};
+            line-height: 1.4;
+            margin-bottom: ${theme.spacing(3)}px;
           }
         `}</style>
       </React.Fragment>


### PR DESCRIPTION
## Description
Updated InputLabels to be larger and gray.  Updated Input to have slightly smaller padding.  Updated FormGroup title and subtitle styling.

## Notes
Not 100% sure whether I overrode the FormGroup styles correctly.

## Screenshots
![Screenshot_2020-03-05 Screenshot(3)](https://user-images.githubusercontent.com/10818279/76036810-fcd66c80-5ef9-11ea-953e-b46b113b6acd.png)
![Screenshot_2020-03-05 Screenshot(4)](https://user-images.githubusercontent.com/10818279/76036835-17104a80-5efa-11ea-98fb-9fbcc320e283.png)

## Where to Start
/components/form
/components/input