### PR TITLE
[PLT-4906] Emit click event even when menu variant is not selection

### DIFF
--- a/packages/riipen-ui-docs/src/pages/components-api/input-label.md
+++ b/packages/riipen-ui-docs/src/pages/components-api/input-label.md
@@ -22,6 +22,7 @@ You can learn more about the difference by [reading this guide](/guides/bundle-s
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The content of the component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">array</span> | <span class="prop-default">[]</span> | An array of custom CSS classes to apply. |
+| <span class="prop-name">marginBottom</span> | <span class="prop-type">number</span> | <span class="prop-default">3</span> | Margin bottom styling to apply to the label. |
 | <span class="prop-name">required</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If true, an asterisk will be appended to the end of the label. |
 
 

--- a/packages/riipen-ui-docs/src/pages/components-api/menu.md
+++ b/packages/riipen-ui-docs/src/pages/components-api/menu.md
@@ -30,8 +30,8 @@ You can learn more about the difference by [reading this guide](/guides/bundle-s
 | <span class="prop-name">contentPosition</span> | <span class="prop-type">object</span> |  | The location to attach the anchor to on the content element |
 | <span class="prop-name">isOpen</span> | <span class="prop-type">bool</span> | <span class="prop-default">true</span> | Whether or not the menu should be rendered |
 | <span class="prop-name">keepOnScreen</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Whether or not the popout should be forced to stay on screen |
-| <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |  | The function callback for when the selection is changed |
-| <span class="prop-name">onClose</span> | <span class="prop-type">func</span> |  | The function callback to use when the menu closes |
+| <span class="prop-name">onChange</span> | <span class="prop-type">func</span> | <span class="prop-default">() => {}</span> | The function callback for when the selection is changed |
+| <span class="prop-name">onClose</span> | <span class="prop-type">func</span> | <span class="prop-default">() => {}</span> | The function callback to use when the menu closes |
 | <span class="prop-name">popoverStyles</span> | <span class="prop-type">object</span> | <span class="prop-default">{}</span> | The styles to be applied to the popover list |
 | <span class="prop-name">selectedIndex</span> | <span class="prop-type">number</span> |  | The index of the item selected in the list |
 | <span class="prop-name">variant</span> | <span class="prop-type">"menu"<br>&#124;&nbsp;"selection"</span> | <span class="prop-default">"menu"</span> | The type of menu to create Use 'menu' for lists of links |

--- a/packages/riipen-ui-docs/src/pages/components-api/menu.md
+++ b/packages/riipen-ui-docs/src/pages/components-api/menu.md
@@ -30,8 +30,8 @@ You can learn more about the difference by [reading this guide](/guides/bundle-s
 | <span class="prop-name">contentPosition</span> | <span class="prop-type">object</span> |  | The location to attach the anchor to on the content element |
 | <span class="prop-name">isOpen</span> | <span class="prop-type">bool</span> | <span class="prop-default">true</span> | Whether or not the menu should be rendered |
 | <span class="prop-name">keepOnScreen</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Whether or not the popout should be forced to stay on screen |
-| <span class="prop-name">onChange</span> | <span class="prop-type">func</span> | <span class="prop-default">() => {}</span> | The function callback for when the selection is changed |
-| <span class="prop-name">onClose</span> | <span class="prop-type">func</span> | <span class="prop-default">() => {}</span> | The function callback to use when the menu closes |
+| <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |  | The function callback for when the selection is changed |
+| <span class="prop-name">onClose</span> | <span class="prop-type">func</span> |  | The function callback to use when the menu closes |
 | <span class="prop-name">popoverStyles</span> | <span class="prop-type">object</span> | <span class="prop-default">{}</span> | The styles to be applied to the popover list |
 | <span class="prop-name">selectedIndex</span> | <span class="prop-type">number</span> |  | The index of the item selected in the list |
 | <span class="prop-name">variant</span> | <span class="prop-type">"menu"<br>&#124;&nbsp;"selection"</span> | <span class="prop-default">"menu"</span> | The type of menu to create Use 'menu' for lists of links |

--- a/packages/riipen-ui/package.json
+++ b/packages/riipen-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riipen-ui",
-  "version": "0.0.78",
+  "version": "0.0.79",
   "private": false,
   "author": {
     "name": "Riipen",

--- a/packages/riipen-ui/package.json
+++ b/packages/riipen-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riipen-ui",
-  "version": "0.0.77",
+  "version": "0.0.78",
   "private": false,
   "author": {
     "name": "Riipen",

--- a/packages/riipen-ui/package.json
+++ b/packages/riipen-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riipen-ui",
-  "version": "0.0.75",
+  "version": "0.0.77",
   "private": false,
   "author": {
     "name": "Riipen",

--- a/packages/riipen-ui/src/components/Menu.jsx
+++ b/packages/riipen-ui/src/components/Menu.jsx
@@ -92,6 +92,8 @@ class Menu extends React.Component {
     closeOnClick: true,
     isOpen: true,
     keepOnScreen: false,
+    onChange: () => {},
+    onClose: () => {},
     popoverStyles: {},
     variant: "menu"
   };
@@ -104,9 +106,9 @@ class Menu extends React.Component {
   }
 
   handleChange = (idx, event) => {
-    const { onChange, closeOnClick } = this.props;
-    if (closeOnClick && event && event.type === "click") this.handleClose(idx);
-    if (onChange) onChange(idx, event);
+    const { onChange, closeOnClick, onClose } = this.props;
+    if (closeOnClick && event && event.type === "click") onClose(idx);
+    onChange(idx, event);
   };
 
   render() {

--- a/packages/riipen-ui/src/components/Menu.jsx
+++ b/packages/riipen-ui/src/components/Menu.jsx
@@ -92,8 +92,6 @@ class Menu extends React.Component {
     closeOnClick: true,
     isOpen: true,
     keepOnScreen: false,
-    onChange: () => {},
-    onClose: () => {},
     popoverStyles: {},
     variant: "menu"
   };
@@ -107,8 +105,9 @@ class Menu extends React.Component {
 
   handleChange = (idx, event) => {
     const { onChange, closeOnClick, onClose } = this.props;
-    if (closeOnClick && event && event.type === "click") onClose(idx);
-    onChange(idx, event);
+    if (onClose && closeOnClick && event && event.type === "click")
+      onClose(idx);
+    if (onChange) onChange(idx, event);
   };
 
   render() {

--- a/packages/riipen-ui/src/components/MenuList.jsx
+++ b/packages/riipen-ui/src/components/MenuList.jsx
@@ -160,7 +160,7 @@ class MenuList extends React.Component {
       <React.Fragment>
         <div
           className={clsx(classes)}
-          onClick={event => this.handleClick(null, event)}
+          onClick={() => this.handleSelectChange(null, event)}
         >
           {this.getListItems(children, selectedIndex)}
         </div>

--- a/packages/riipen-ui/src/components/MenuList.jsx
+++ b/packages/riipen-ui/src/components/MenuList.jsx
@@ -158,7 +158,10 @@ class MenuList extends React.Component {
 
     return (
       <React.Fragment>
-        <div className={clsx(classes)}>
+        <div
+          className={clsx(classes)}
+          onClick={event => this.handleClick(null, event)}
+        >
           {this.getListItems(children, selectedIndex)}
         </div>
       </React.Fragment>


### PR DESCRIPTION
## Description
Added click event to menu list div that emits null event
This is useful for menus that dont have indexes to know when an option in the menu has been selected