### PR TITLE
Full width popover investigation

### DIFF
--- a/packages/riipen-ui/src/components/Menu.jsx
+++ b/packages/riipen-ui/src/components/Menu.jsx
@@ -80,6 +80,11 @@ class Menu extends React.Component {
     selectedIndex: PropTypes.number,
 
     /**
+     * The margins of the page the popover should respect
+     */
+    marginThreshold: PropTypes.number,
+
+    /**
      * The type of menu to create
      * Use 'menu' for lists of links
      */
@@ -124,6 +129,7 @@ class Menu extends React.Component {
       popoverStyles,
       selectedIndex,
       variant,
+      marginThreshold,
       ...other
     } = this.props;
 
@@ -138,6 +144,7 @@ class Menu extends React.Component {
           anchorEl={anchorEl}
           styles={popoverStyles}
           keepOnScreen={keepOnScreen}
+          marginThreshold={marginThreshold}
         >
           <MenuList
             selectChange={this.handleChange}

--- a/packages/riipen-ui/src/components/Popover.jsx
+++ b/packages/riipen-ui/src/components/Popover.jsx
@@ -61,7 +61,7 @@ class Popover extends React.Component {
     lockScroll: PropTypes.bool,
 
     /**
-     * The marigins of the page the popover should respect
+     * The margins of the page the popover should respect
      */
     marginThreshold: PropTypes.number,
 
@@ -157,6 +157,7 @@ class Popover extends React.Component {
 
   setPositioningStyle = () => {
     const contentRef = this.contentRef.current;
+
     const {
       anchorPosition = {
         vertical: "top",
@@ -170,12 +171,14 @@ class Popover extends React.Component {
     } = this.props;
 
     const anchorEl = this.getAnchorEl();
+    console.log(anchorEl);
     if (!anchorEl || !contentRef) return;
 
     // Set top and left of element based on location of anchor
     const anchorRect = anchorEl.getBoundingClientRect();
     let top = anchorRect.top;
     let left = anchorRect.left;
+    console.log("from anchorRect,", { top, left });
 
     // Offset Content Based on anchorPosition props
     const anchorVerticalOffset = getOffsetTop(
@@ -187,11 +190,18 @@ class Popover extends React.Component {
       anchorPosition.horizontal
     );
 
+    console.log({ anchorVerticalOffset, anchorHorizonalOffset });
+
     top += anchorVerticalOffset;
     left += anchorHorizonalOffset;
 
+    console.log("after anchorHorizontalOffset,", { left });
+
     // Offset Content Based on contentPosition props
     const contentRect = contentRef.getBoundingClientRect();
+    console.log("contentRef: ", contentRef);
+
+    console.log("contentRect:", contentRect);
 
     const contentVerticalOffset = getOffsetTop(
       contentRect,
@@ -202,8 +212,11 @@ class Popover extends React.Component {
       contentPosition.horizontal
     );
 
+    console.log({ contentVerticalOffset, contentHorizontalOffset });
+
     top -= contentVerticalOffset;
     left -= contentHorizontalOffset;
+    console.log("After contentHorizontalOffset:", { left });
 
     // Move menu back into view if out of screen
     if (keepOnScreen) {
@@ -212,6 +225,8 @@ class Popover extends React.Component {
 
       const heightMax = viewContainer.innerHeight - marginThreshold;
       const widthMax = viewContainer.innerWidth - marginThreshold;
+
+      console.log({ heightMax, widthMax, marginThreshold });
 
       // Check Vertical Constraints
       if (top + contentRect.height > heightMax) {
@@ -222,15 +237,11 @@ class Popover extends React.Component {
 
       // Check Horizontal Constraints
       if (left + contentRect.width > widthMax) {
-        left -= left + contentRect.width - widthMax;
+        left = contentRect.width - widthMax;
       } else if (left < marginThreshold) {
         left = marginThreshold;
       }
-    }
-
-    // Handle full-width menu
-    if (anchorPosition.horizontal === "full-width") {
-      left = 0;
+      console.log("after keepOnScreen:", { top, left });
     }
 
     this.setState(
@@ -315,8 +326,7 @@ class Popover extends React.Component {
       children,
       component,
       styles,
-      isOpen,
-      anchorPosition
+      isOpen
     } = this.props;
     const theme = this.context;
     const className = clsx(classes, "popover", { open: isOpen });
@@ -340,20 +350,11 @@ class Popover extends React.Component {
             box-shadow: ${theme.shadows[4]};
             box-sizing: border-box;
             max-height: calc(100% - 32px);
-            max-width: ${
-              anchorPosition?.horizontal === "full-width"
-                ? "100%"
-                : "calc(100% - 32px)"
-            };
+            max-width: calc(100% - 32px);
             min-height: 16px;
             min-width: 16px;
             outline: 0;
             position: absolute;
-            ${
-              anchorPosition?.horizontal === "full-width"
-                ? "width: 100%;"
-                : null
-            }
             z-index: ${theme.zIndex.middle};
           }
 

--- a/packages/riipen-ui/src/components/Popover.jsx
+++ b/packages/riipen-ui/src/components/Popover.jsx
@@ -340,13 +340,20 @@ class Popover extends React.Component {
             box-shadow: ${theme.shadows[4]};
             box-sizing: border-box;
             max-height: calc(100% - 32px);
-            max-width: ${anchorPosition?.horizontal === "full-width"
-              ? "100%"
-              : "calc(100% - 32px)"};
+            max-width: ${
+              anchorPosition?.horizontal === "full-width"
+                ? "100%"
+                : "calc(100% - 32px)"
+            };
             min-height: 16px;
             min-width: 16px;
             outline: 0;
             position: absolute;
+            ${
+              anchorPosition?.horizontal === "full-width"
+                ? "width: 100%;"
+                : null
+            }
             z-index: ${theme.zIndex.middle};
           }
 

--- a/packages/riipen-ui/src/components/Popover.jsx
+++ b/packages/riipen-ui/src/components/Popover.jsx
@@ -228,6 +228,11 @@ class Popover extends React.Component {
       }
     }
 
+    // Handle full-width menu
+    if (anchorPosition.horizontal === "full-width") {
+      left = 0;
+    }
+
     this.setState(
       Object.assign(this.state, {
         contentStyles: {
@@ -310,7 +315,8 @@ class Popover extends React.Component {
       children,
       component,
       styles,
-      isOpen
+      isOpen,
+      anchorPosition
     } = this.props;
     const theme = this.context;
     const className = clsx(classes, "popover", { open: isOpen });
@@ -334,7 +340,9 @@ class Popover extends React.Component {
             box-shadow: ${theme.shadows[4]};
             box-sizing: border-box;
             max-height: calc(100% - 32px);
-            max-width: calc(100% - 32px);
+            max-width: ${anchorPosition?.horizontal === "full-width"
+              ? "100%"
+              : "calc(100% - 32px)"};
             min-height: 16px;
             min-width: 16px;
             outline: 0;


### PR DESCRIPTION
## Description
* When `popoverStyles={{width:"100vw",maxWidth:"100%"}}` is passed into `Menu` (thereby passing `styles={{width:"100vw",maxWidth:"100%"}}` into `Popover`, the first time the popover is opened, it has a 'left' property `!== 0`.
* contentRef.getClientBoundingRect() is not returning the actual width of the element the first time it is opened. (see screenshots for discrepancy)

## Notes
* Further investigation is needed -- opening this PR for future use.
* For now, a full-width prop (https://github.com/riipen/ui/pull/32) will be used to allow popover to take up full screen width for mobile views.

## Screenshots
console.log of getBoundingClientRect()
![element getBoundingClientRect](https://user-images.githubusercontent.com/36321777/77338693-13096880-6d01-11ea-9ec0-42bd7583211d.jpg)

Actual element width
![element properties](https://user-images.githubusercontent.com/36321777/77338697-143a9580-6d01-11ea-8cbd-fb289eb6e6fb.jpg)

## Where to Start
components/Popover.js
components/Menu.js