### PR TITLE
add handleFragmentChildren

### DIFF
--- a/packages/riipen-ui/src/components/MenuList.jsx
+++ b/packages/riipen-ui/src/components/MenuList.jsx
@@ -106,7 +106,7 @@ class MenuList extends React.Component {
   }
 
   keyDownHandler = event => {
-    const { selectedIndex, children } = this.props;
+    const { children, selectedIndex } = this.props;
     const nextEvents = ["ArrowDown", "ArrowRight"];
     const prevEvents = ["ArrowUp", "ArrowLeft"];
     const enterEvent = "Enter";

--- a/packages/riipen-ui/src/components/MenuList.jsx
+++ b/packages/riipen-ui/src/components/MenuList.jsx
@@ -69,26 +69,31 @@ class MenuList extends React.Component {
   getListItems(children, activeItemIndex) {
     const { variant } = this.props;
 
-    return React.Children.map(children, (child, idx) => {
-      let newProps = {
-        key: idx,
-        color: this.props.color
-      };
-      if (variant === "selection") {
-        newProps = Object.assign(newProps, {
-          onClick: this.handleClick(child, idx)
-        });
-        if (idx === activeItemIndex) {
+    return React.Children.map(
+      this.handleFragmentChildren(children),
+      (child, idx) => {
+        let newProps = {
+          key: idx,
+          color: this.props.color
+        };
+
+        if (variant === "selection") {
           newProps = Object.assign(newProps, {
-            selected: true
+            onClick: this.handleClick(child, idx)
           });
+          if (idx === activeItemIndex) {
+            newProps = Object.assign(newProps, {
+              selected: true
+            });
+          }
         }
+
+        return React.cloneElement(child, {
+          ...child.props,
+          ...newProps
+        });
       }
-      return React.cloneElement(child, {
-        ...child.props,
-        ...newProps
-      });
-    });
+    );
   }
 
   static contextType = ThemeContext;
@@ -101,7 +106,7 @@ class MenuList extends React.Component {
   }
 
   keyDownHandler = event => {
-    const { children, selectedIndex } = this.props;
+    const { selectedIndex, children } = this.props;
     const nextEvents = ["ArrowDown", "ArrowRight"];
     const prevEvents = ["ArrowUp", "ArrowLeft"];
     const enterEvent = "Enter";
@@ -151,6 +156,17 @@ class MenuList extends React.Component {
       if (child.props.disabled) return;
       this.handleSelectChange(idx, event);
     };
+  };
+
+  handleFragmentChildren = children => {
+    let handledChildren = children;
+
+    if (!Array.isArray(handledChildren)) {
+      if (handledChildren.type.toString().includes("react.fragment")) {
+        handledChildren = this.handleFragmentChildren(children.props.children);
+      }
+    }
+    return handledChildren;
   };
 
   render() {

--- a/packages/riipen-ui/src/components/MenuList.jsx
+++ b/packages/riipen-ui/src/components/MenuList.jsx
@@ -159,14 +159,9 @@ class MenuList extends React.Component {
   };
 
   handleFragmentChildren = children => {
-    let handledChildren = children;
-
-    if (!Array.isArray(handledChildren)) {
-      if (handledChildren.type.toString().includes("react.fragment")) {
-        handledChildren = this.handleFragmentChildren(children.props.children);
-      }
-    }
-    return handledChildren;
+      return children.type === React.Fragment
+            ? children.props.children
+            : children;
   };
 
   render() {


### PR DESCRIPTION
## Description
* If a MenuList's children were wrapped in a React.Fragment, the 'color' prop was not being passed as expected
* Add `handleFragmentChildren()` to `getListItems`
## Notes

## Screenshots

## Where to Start
/components/MenuList