### PR TITLE
fix build command to not crash web when rebuilt

### DIFF
--- a/packages/riipen-ui/package.json
+++ b/packages/riipen-ui/package.json
@@ -30,7 +30,7 @@
   },
   "sideEffects": false,
   "scripts": {
-    "build": "babel ./src --out-dir ./temp && cp ./package.json ./temp && cp ./README.md ./temp && rsync ./temp/ ./build/ -r --delete-after",
+    "build": "babel ./src --out-dir ./temp && cp ./package.json ./temp && cp ./README.md ./temp && rsync ./temp/ ./build/ -r --delete-after && rm -rf ./temp",
     "ci:audit": "audit-ci --moderate",
     "ci:test:coverage": "NODE_ENV=test NODE_PATH=./ nyc mocha --opts ./test/unit/ci.mocha.opts",
     "format": "prettier --write \"**/*.{js,jsx}\"",

--- a/packages/riipen-ui/package.json
+++ b/packages/riipen-ui/package.json
@@ -30,12 +30,11 @@
   },
   "sideEffects": false,
   "scripts": {
-    "build": "babel ./src --out-dir ./build && cp ./package.json ./build && cp ./README.md ./build",
+    "build": "babel ./src --out-dir ./temp && cp ./package.json ./temp && cp ./README.md ./temp && rsync ./temp/ ./build/ -r --delete-after",
     "ci:audit": "audit-ci --moderate",
     "ci:test:coverage": "NODE_ENV=test NODE_PATH=./ nyc mocha --opts ./test/unit/ci.mocha.opts",
     "format": "prettier --write \"**/*.{js,jsx}\"",
     "lint": "eslint .",
-    "prebuild": "rm -fr ./build",
     "precommit": "lint-staged",
     "release": "npm run build && npm publish build --tag latest"
   },


### PR DESCRIPTION
## Description
running `npm run build` on `riipen-ui` when `/web` had a `symlink` to `riipen-ui/build` caused `/web` server to crash on some machines. 

* This change causes `npm run build` not to run `rm -rf ./build` before building.
* Instead, build is made in `./temp`, then `./temp` is transferred to `./build`. 
* `./temp` is deleted afterwards

 
## Notes
Thank you @kradical for investigating + solving this issue 
## Screenshots

## Where to Start
