### PR TITLE
[PLT-5037]: return empty string if not fullWidth

### DIFF
--- a/packages/riipen-ui/package.json
+++ b/packages/riipen-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riipen-ui",
-  "version": "0.0.96",
+  "version": "0.0.97",
   "private": false,
   "author": {
     "name": "Riipen",

--- a/packages/riipen-ui/src/components/Popover.jsx
+++ b/packages/riipen-ui/src/components/Popover.jsx
@@ -352,7 +352,7 @@ class Popover extends React.Component {
             min-width: 16px;
             outline: 0;
             position: absolute;
-            ${fullWidth ? "width: 100%;" : null}
+            ${fullWidth ? "width: 100%;" : ""}
             z-index: ${theme.zIndex.middle};
           }
 


### PR DESCRIPTION
## Description
Return empty string if not fullWidth so that popovers have the correct z-index.

## Where to Start
components/Popover