### PR TITLE
Make buttons the same size

### DIFF
--- a/packages/riipen-ui-docs/src/pages/components/button/Contained.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/button/Contained.jsx
@@ -28,9 +28,11 @@ export default function Contained() {
       <Button color="white" variant="contained">
         White
       </Button>
+      <span style={style} />
       <Button color="positive" variant="contained">
         Positive
       </Button>
+      <span style={style} />
       <Button color="negative" variant="contained">
         Negative
       </Button>

--- a/packages/riipen-ui-docs/src/pages/components/button/Outlined.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/button/Outlined.jsx
@@ -28,9 +28,11 @@ export default function Outlined() {
       <Button color="white" variant="outlined">
         White
       </Button>
+      <span style={style} />
       <Button color="positive" variant="outlined">
         Positive
       </Button>
+      <span style={style} />
       <Button color="negative" variant="outlined">
         Negative
       </Button>

--- a/packages/riipen-ui-docs/src/pages/components/button/Text.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/button/Text.jsx
@@ -28,9 +28,11 @@ export default function Text() {
       <Button color="white" variant="text">
         White
       </Button>
+      <span style={style} />
       <Button color="positive" variant="text">
         Positive
       </Button>
+      <span style={style} />
       <Button color="negative" variant="text">
         Negative
       </Button>

--- a/packages/riipen-ui/src/components/Button.jsx
+++ b/packages/riipen-ui/src/components/Button.jsx
@@ -320,6 +320,16 @@ class Button extends React.Component {
             background-color: ${theme.palette.negative.main};
           }
 
+          .outlined.small {
+            padding: calc(${theme.spacing(1)}px - 1px)
+              calc(${theme.spacing(2)}px - 1px);
+          }
+
+          .outlined.large {
+            padding: calc(${theme.spacing(3)}px - 1px)
+              calc(${theme.spacing(5)}px - 1px);
+          }
+
           .outlined {
             background-color: transparent;
             border: 1px solid rgba(0, 0, 0, 0.23);

--- a/packages/riipen-ui/src/components/Button.jsx
+++ b/packages/riipen-ui/src/components/Button.jsx
@@ -204,9 +204,13 @@ class Button extends React.Component {
             padding: ${theme.spacing(3)}px ${theme.spacing(5)}px;
           }
 
-          .contained {
+          .contained,
+          .text {
             border: 0;
+            padding: calc(${theme.spacing(2)}px + 1px)
+              calc(${theme.spacing(3)}px + 1px);
           }
+
           .contained-primary {
             background-color: ${theme.palette.primary.main};
             color: ${theme.palette.primary.contrast};
@@ -264,7 +268,6 @@ class Button extends React.Component {
 
           .text {
             background-color: transparent;
-            border: 0;
             color: ${theme.palette.text.primary};
             overflow: hidden;
             position: relative;

--- a/packages/riipen-ui/src/components/Button.jsx
+++ b/packages/riipen-ui/src/components/Button.jsx
@@ -149,9 +149,8 @@ class Button extends React.Component {
         <style jsx>{`
           .root {
             background-color: ${theme.palette.grey[300]};
+            border: 0;
             border-radius: ${theme.shape.borderRadius.md};
-            border-style: solid;
-            border-width: 1px;
             color: ${theme.palette.text.primary};
             cursor: pointer;
             display: inline-flex;
@@ -204,9 +203,6 @@ class Button extends React.Component {
             padding: ${theme.spacing(3)}px ${theme.spacing(5)}px;
           }
 
-          .contained {
-            border: 0;
-          }
           .contained-primary {
             background-color: ${theme.palette.primary.main};
             color: ${theme.palette.primary.contrast};
@@ -264,7 +260,6 @@ class Button extends React.Component {
 
           .text {
             background-color: transparent;
-            border: 0;
             color: ${theme.palette.text.primary};
             overflow: hidden;
             position: relative;
@@ -320,24 +315,21 @@ class Button extends React.Component {
             background-color: ${theme.palette.negative.main};
           }
 
-          .outlined.small {
-            padding: calc(${theme.spacing(1)}px - 1px)
-              calc(${theme.spacing(2)}px - 1px);
-          }
-
-          .outlined.large {
-            padding: calc(${theme.spacing(3)}px - 1px)
-              calc(${theme.spacing(5)}px - 1px);
-          }
-
           .outlined {
             background-color: transparent;
-            border: 1px solid rgba(0, 0, 0, 0.23);
             color: ${theme.palette.text.primary};
             overflow: hidden;
-            padding: calc(${theme.spacing(2)}px - 1px)
-              calc(${theme.spacing(3)}px - 1px);
             position: relative;
+          }
+          .outlined::after {
+            border-radius: ${theme.shape.borderRadius.md};
+            border: 1px solid rgba(0, 0, 0, 0.23);
+            bottom: 0;
+            content: "";
+            left: 0;
+            position: absolute;
+            right: 0;
+            top: 0;
           }
           .outlined:hover {
             background-color: transparent;
@@ -354,46 +346,58 @@ class Button extends React.Component {
           }
 
           .outlined-primary {
-            border-color: ${theme.palette.primary.main};
             color: ${theme.palette.primary.main};
           }
           .outlined-primary:hover::before {
             background-color: ${theme.palette.primary.main};
           }
+          .outlined-primary::after {
+            border-color: ${theme.palette.primary.main};
+          }
           .outlined-secondary {
-            border-color: ${theme.palette.secondary.main};
             color: ${theme.palette.secondary.main};
           }
           .outlined-secondary:hover::before {
             background-color: ${theme.palette.secondary.main};
           }
+          .outlined-secondary::after {
+            border-color: ${theme.palette.secondary.main};
+          }
           .outlined-tertiary {
-            border-color: ${theme.palette.tertiary.main};
             color: ${theme.palette.tertiary.main};
           }
           .outlined-tertiary:hover::before {
             background-color: ${theme.palette.tertiary.main};
           }
+          .outlined-tertiary::after {
+            border-color: ${theme.palette.tertiary.main};
+          }
           .outlined-white {
-            border-color: ${theme.palette.common.white};
             color: ${theme.palette.common.white};
           }
           .outlined-white:hover::before {
             background-color: ${theme.palette.grey[100]};
           }
+          .outlined-white::after {
+            border-color: ${theme.palette.common.white};
+          }
           .outlined-positive {
-            border-color: ${theme.palette.positive.main};
             color: ${theme.palette.positive.main};
           }
           .outlined-positive:hover::before {
             background-color: ${theme.palette.positive.main};
           }
+          .outlined-positive::after {
+            border-color: ${theme.palette.positive.main};
+          }
           .outlined-negative {
-            border-color: ${theme.palette.negative.main};
             color: ${theme.palette.negative.main};
           }
           .outlined-negative:hover::before {
             background-color: ${theme.palette.negative.main};
+          }
+          .outlined-negative::after {
+            border-color: ${theme.palette.negative.main};
           }
 
           .label {

--- a/packages/riipen-ui/src/components/Button.jsx
+++ b/packages/riipen-ui/src/components/Button.jsx
@@ -173,7 +173,7 @@ class Button extends React.Component {
           }
 
           .icon {
-            font-size: 16px;
+            font-size: 15px;
           }
           .icon > svg {
             display: flex;
@@ -204,13 +204,9 @@ class Button extends React.Component {
             padding: ${theme.spacing(3)}px ${theme.spacing(5)}px;
           }
 
-          .contained,
-          .text {
+          .contained {
             border: 0;
-            padding: calc(${theme.spacing(2)}px + 1px)
-              calc(${theme.spacing(3)}px + 1px);
           }
-
           .contained-primary {
             background-color: ${theme.palette.primary.main};
             color: ${theme.palette.primary.contrast};
@@ -268,6 +264,7 @@ class Button extends React.Component {
 
           .text {
             background-color: transparent;
+            border: 0;
             color: ${theme.palette.text.primary};
             overflow: hidden;
             position: relative;
@@ -328,6 +325,8 @@ class Button extends React.Component {
             border: 1px solid rgba(0, 0, 0, 0.23);
             color: ${theme.palette.text.primary};
             overflow: hidden;
+            padding: calc(${theme.spacing(2)}px - 1px)
+              calc(${theme.spacing(3)}px - 1px);
             position: relative;
           }
           .outlined:hover {
@@ -395,6 +394,7 @@ class Button extends React.Component {
             font-weight: ${theme.typography.fontWeight.medium};
             justify-content: center;
             letter-spacing: 1px;
+            line-height: 15px;
             text-align: center;
             text-transform: uppercase;
             width: 100%;


### PR DESCRIPTION
## Description
-Added line height so that buttons with/without icons are the same height
-Decreased the padding of outlined buttons by 1 px to accommodate the 1 px border
-Updated the spacing to some buttons in the examples

## Notes
There's still one really pesky thing going on with buttons with icons: buttons with an iconStart prop display slightly higher than other buttons.  I _think_ something is going on with the flex container, but still can't quite pinpoint the behaviour.  See attached screenshot and also https://ui.riipen.com/components/button/#icons.

## Screenshots
![Screenshot_2020-03-31 Screenshot](https://user-images.githubusercontent.com/10818279/78083482-7a12c700-736a-11ea-9000-74e720a79b7d.png)
![Screenshot_2020-03-31 Screenshot(1)](https://user-images.githubusercontent.com/10818279/78083488-7c752100-736a-11ea-8ff3-28af7cb631a4.png)
![Screenshot_2020-03-31 Screenshot(2)](https://user-images.githubusercontent.com/10818279/78083477-7717d680-736a-11ea-81ed-11c1972b8ca7.png)

## Where to Start
