### PR TITLE
[PLT-4595]: decrease border-left to 3px

### DIFF
--- a/packages/riipen-ui/package.json
+++ b/packages/riipen-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riipen-ui",
-  "version": "0.0.100",
+  "version": "0.0.101",
   "private": false,
   "author": {
     "name": "Riipen",

--- a/packages/riipen-ui/src/components/MenuItem.jsx
+++ b/packages/riipen-ui/src/components/MenuItem.jsx
@@ -52,7 +52,7 @@ class MenuItem extends React.Component {
 
     return css.resolve`
       .menu-item {
-        border-left: 5px solid transparent;
+        border-left: 3px solid transparent;
         box-sizing: border-box;
         color: ${theme.palette.text.secondary};
         cursor: pointer;


### PR DESCRIPTION
## Description
* border-left on dropdown items should be 3px (from navbar redesign)
[PLT-4595](https://riipen.atlassian.net/browse/PLT-4595?focusedCommentId=21349&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-21349)

## Notes

## Screenshots
3px border-left
![Screen Shot 2020-04-06 at 11 36 06 AM](https://user-images.githubusercontent.com/36321777/78576540-cfcbf100-77fa-11ea-9550-026f7038423c.png)


## Where to Start
