### PR TITLE
Update tooltip visibility

### DIFF
--- a/packages/riipen-ui/src/components/Tooltip.jsx
+++ b/packages/riipen-ui/src/components/Tooltip.jsx
@@ -113,6 +113,7 @@ class Tooltip extends React.Component {
       .popover {
         border-radius: 2px;
         color: ${theme.palette.common.white};
+        display: none;
       }
 
       @keyframes fade {
@@ -128,6 +129,7 @@ class Tooltip extends React.Component {
       .popover.show {
         animation: fade ${theme.transitions.duration.short}ms
           ${theme.transitions.easing.easeIn};
+        display: block;
       }
 
       /* Sizes */
@@ -466,7 +468,6 @@ class Tooltip extends React.Component {
           horizontal: contentHorizontal,
           vertical: contentVertical
         }}
-        isOpen={open}
         anchorEl={this.tooltipRootRef.current}
         keepOnScreen
         lockScroll={false}

--- a/packages/riipen-ui/src/components/Tooltip.jsx
+++ b/packages/riipen-ui/src/components/Tooltip.jsx
@@ -1,4 +1,3 @@
-import clsx from "clsx";
 import PropTypes from "prop-types";
 import React from "react";
 import css from "styled-jsx/css";
@@ -105,11 +104,6 @@ class Tooltip extends React.Component {
     const theme = this.context;
 
     return css.resolve`
-      .wrapper {
-        height: max-content;
-        width: max-content;
-      }
-
       .popover {
         border-radius: 2px;
         color: ${theme.palette.common.white};
@@ -474,7 +468,7 @@ class Tooltip extends React.Component {
         onClose={this.handleClose}
         {...other}
       >
-        {tooltip}
+        <React.Fragment>{tooltip}</React.Fragment>
       </Popover>
     );
   };
@@ -486,11 +480,10 @@ class Tooltip extends React.Component {
     return (
       <React.Fragment>
         <Component
-          className={clsx(linkedStyles.className, "wrapper")}
           ref={this.tooltipRootRef}
           onClick={click ? this.clickCallback : undefined}
           onMouseOver={hover ? this.handleOpen : undefined}
-          onMouseOut={hover ? this.handleClose : undefined}
+          onMouseLeave={hover ? this.handleClose : undefined}
         >
           {children}
         </Component>

--- a/packages/riipen-ui/src/components/Tooltip.jsx
+++ b/packages/riipen-ui/src/components/Tooltip.jsx
@@ -113,7 +113,6 @@ class Tooltip extends React.Component {
       .popover {
         border-radius: 2px;
         color: ${theme.palette.common.white};
-        display: none;
       }
 
       @keyframes fade {
@@ -129,7 +128,6 @@ class Tooltip extends React.Component {
       .popover.show {
         animation: fade ${theme.transitions.duration.short}ms
           ${theme.transitions.easing.easeIn};
-        display: block;
       }
 
       /* Sizes */
@@ -199,6 +197,7 @@ class Tooltip extends React.Component {
         border-width: ${theme.spacing(2)}px;
         content: "";
         position: absolute;
+        white-space: normal;
       }
 
       /* Tooltip arrow inside */
@@ -208,6 +207,7 @@ class Tooltip extends React.Component {
         border-width: calc(${theme.spacing(2)}px - 1px);
         content: "";
         position: absolute;
+        white-space: normal;
       }
 
       .popover.bottom {
@@ -450,7 +450,6 @@ class Tooltip extends React.Component {
 
     return (
       <Popover
-        {...other}
         classes={classes.concat([
           linkedStyles.className,
           "popover",
@@ -469,9 +468,11 @@ class Tooltip extends React.Component {
           vertical: contentVertical
         }}
         anchorEl={this.tooltipRootRef.current}
+        isOpen={open}
         keepOnScreen
         lockScroll={false}
         onClose={this.handleClose}
+        {...other}
       >
         {tooltip}
       </Popover>


### PR DESCRIPTION
## Description
Move passing props to the Popover in the Tooltip component to allow for some overrides.  Also fix an issue with whitespace and the tooltip arrows.

## Where to Start
/components/Tooltip
