### PR TITLE
[PLT-5120]: Add outline prop to ButtonIcon

### DIFF
--- a/packages/riipen-ui/package.json
+++ b/packages/riipen-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riipen-ui",
-  "version": "0.0.108",
+  "version": "0.0.109",
   "private": false,
   "author": {
     "name": "Riipen",

--- a/packages/riipen-ui/src/components/ButtonIcon.jsx
+++ b/packages/riipen-ui/src/components/ButtonIcon.jsx
@@ -41,6 +41,11 @@ class ButtonIcon extends React.Component {
     disabled: PropTypes.bool,
 
     /**
+     * If `true`, the button will have an outline. If `false` the button will not have an outline when focussed.
+     */
+    outline: PropTypes.bool,
+
+    /**
      * The size of the chip.
      */
     size: PropTypes.oneOf(["small", "medium", "large"])
@@ -50,6 +55,7 @@ class ButtonIcon extends React.Component {
     classes: [],
     color: "default",
     disabled: false,
+    outline: false,
     size: "medium"
   };
 
@@ -62,6 +68,7 @@ class ButtonIcon extends React.Component {
       color,
       component,
       disabled,
+      outline,
       size,
       ...other
     } = this.props;
@@ -96,7 +103,7 @@ class ButtonIcon extends React.Component {
             display: inline-flex;
             padding: ${theme.spacing(2)}px;
             position: relative;
-            outline: 0;
+            ${outline ? "" : "outline: 0;"}
             transition: all ${theme.transitions.duration.standard}ms;
             user-select: none;
           }

--- a/packages/riipen-ui/src/components/ButtonIcon.jsx
+++ b/packages/riipen-ui/src/components/ButtonIcon.jsx
@@ -41,7 +41,7 @@ class ButtonIcon extends React.Component {
     disabled: PropTypes.bool,
 
     /**
-     * If `true`, the button will have an outline. If `false` the button will not have an outline when focussed.
+     * If `true`, the button will have an outline when focussed. If `false` the button will not have an outline when focussed.
      */
     outline: PropTypes.bool,
 


### PR DESCRIPTION
Relates to [[PLT-5120]](https://riipen.atlassian.net/browse/PLT-5120)

## Description
* Add outline prop to `ButtonIcon` to improve accessibility
* Required for https://github.com/riipen/web/pull/2475
* Bump package version

## Notes
* Should likely have this default to true so that all `ButtonIcon` components are accessible, but have put as false for now until discussion determines we want all `ButtonIcon` components to have outline by default

## Screenshots
![outline](https://user-images.githubusercontent.com/36321777/81444793-bdb8d780-9145-11ea-8acd-e38e6f511541.gif)


## Where to Start
