### PR TITLE
[PLT-5122] Added accessibility attributes to tabs and checkboxes

### DIFF
--- a/packages/riipen-ui-docs/src/pages/components-api/button-icon.md
+++ b/packages/riipen-ui-docs/src/pages/components-api/button-icon.md
@@ -22,9 +22,10 @@ You can learn more about the difference by [reading this guide](/guides/bundle-s
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name required">children&nbsp;*</span> | <span class="prop-type">node</span> |  | The icon element. |
 | <span class="prop-name">classes</span> | <span class="prop-type">array</span> | <span class="prop-default">[]</span> | List of additional classes to apply to this component. |
-| <span class="prop-name">color</span> | <span class="prop-type">"default"<br>&#124;&nbsp;"primary"<br>&#124;&nbsp;"secondary"<br>&#124;&nbsp;"tertiary"<br>&#124;&nbsp;"white"</span> | <span class="prop-default">"default"</span> | The color to use. |
+| <span class="prop-name">color</span> | <span class="prop-type">"default"<br>&#124;&nbsp;"muted"<br>&#124;&nbsp;"primary"<br>&#124;&nbsp;"secondary"<br>&#124;&nbsp;"tertiary"<br>&#124;&nbsp;"white"</span> | <span class="prop-default">"default"</span> | The color to use. |
 | <span class="prop-name">component</span> | <span class="prop-type">elementType</span> |  | The component used for the root node. Either a string to use a DOM element or a component. |
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the button will be disabled. |
+| <span class="prop-name">outline</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the button will have an outline when focussed. If `false` the button will not have an outline when focussed. |
 | <span class="prop-name">size</span> | <span class="prop-type">"small"<br>&#124;&nbsp;"medium"<br>&#124;&nbsp;"large"</span> | <span class="prop-default">"medium"</span> | The size of the chip. |
 
 

--- a/packages/riipen-ui/package.json
+++ b/packages/riipen-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riipen-ui",
-  "version": "0.0.110",
+  "version": "0.0.111",
   "private": false,
   "author": {
     "name": "Riipen",

--- a/packages/riipen-ui/src/components/Checkbox.jsx
+++ b/packages/riipen-ui/src/components/Checkbox.jsx
@@ -145,6 +145,10 @@ class Checkbox extends React.Component {
             width: 20px;
           }
 
+          label input:focus ~ .checkmark {
+            outline: -webkit-focus-ring-color auto 5px;
+          }
+
           /* When the checkbox is checked */
           label input:checked ~ .checkmark {
             background-color: ${theme.palette.grey[400]};

--- a/packages/riipen-ui/src/components/Tab.jsx
+++ b/packages/riipen-ui/src/components/Tab.jsx
@@ -71,10 +71,13 @@ class Tab extends React.Component {
 
   static contextType = ThemeContext;
 
-  handleClick = e => {
+  handleChange = e => {
     const { onClick, value } = this.props;
+    if (e.type === "click" || (e.type === "keydown" && e.key === "Enter")) {
+      onClick(e, value);
+    }
 
-    return onClick(e, value);
+    return;
   };
 
   render() {
@@ -104,7 +107,14 @@ class Tab extends React.Component {
 
     return (
       <React.Fragment>
-        <div className={className} onClick={this.handleClick}>
+        <div
+          tabIndex="0"
+          role="button"
+          aria-pressed={active}
+          className={className}
+          onClick={this.handleChange}
+          onKeyDown={this.handleChange}
+        >
           {Icon && <Icon className={clsx("icon")} />}
           {label && <div className={clsx("label")}>{label}</div>}
         </div>
@@ -120,6 +130,11 @@ class Tab extends React.Component {
             padding: ${theme.spacing(3)}px ${theme.spacing(6)}px;
             text-align: center;
             transition: all ${theme.transitions.duration.standard}ms;
+          }
+
+          .root:focus {
+            outline: none;
+            color: ${theme.palette[color].main};
           }
 
           .icon + * {

--- a/packages/riipen-ui/src/components/Tabs.jsx
+++ b/packages/riipen-ui/src/components/Tabs.jsx
@@ -97,7 +97,7 @@ class Tabs extends React.Component {
 
     return (
       <React.Fragment>
-        <Component className={className}>
+        <Component role="tablist" className={className}>
           <div className={clsx("scroller")}>
             <div className={clsx(orientation)}>{childrenWithProps}</div>
           </div>


### PR DESCRIPTION
## Description
Fixed issue where menu items were not keyboard accessible
Fixed issue where outline for checkboxes was not appearing

## Notes
Learned lots about a11y attributes... also, turns out you use space to toggle checkboxes... not enter

## Screenshots
Menus:
![Screen Shot 2020-05-13 at 15 33 47](https://user-images.githubusercontent.com/4382804/81872766-43b29500-952f-11ea-8e0a-0d0e14011cda.png)

Checkboxes:
![Screen Shot 2020-05-13 at 15 34 29](https://user-images.githubusercontent.com/4382804/81872769-444b2b80-952f-11ea-8739-bd1ea4b6532b.png)
