### PR TITLE
Added version update script that detects branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,15 @@ To deploy the documentation server on GitHub Pages:
 $ git push origin production
 ```
 
+## Version Update
+
+In order to update the version run `npm run release` from the `master` or `staging` branches
+
+If ran on the master branch it will release a patch (x.y.z)
+If ran on the staging branch it will release a prerelease (x.y.z-#)
+
+Version updates for minor or major builds will still need to be done manually
+
 ## License
 
 This project is licensed under the terms of the [MIT license](/LICENSE).

--- a/packages/riipen-ui/scripts/update_version.sh
+++ b/packages/riipen-ui/scripts/update_version.sh
@@ -36,7 +36,7 @@ NEW_VERSION=$(npm version $VERSION_CHANGE)
 PARENT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 git add "$(dirname "$0")/../package.json"
 git add "$(dirname "$0")/../package-lock.json"
-git commit -m "Pushed New Version: $VERSION_CHANGE [ci skip]"
+git commit -m "Pushed New $VERSION_CHANGE: $NEW_VERSION [ci skip]"
 git push origin $CURR_BRANCH
 
 # Update git tags

--- a/packages/riipen-ui/scripts/update_version.sh
+++ b/packages/riipen-ui/scripts/update_version.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+CURR_BRANCH=$(git branch --show-current)
+VERSION_CHANGE="prerelease"
+
+verify () {
+  echo "Do you wish to release a new $VERSION_CHANGE?"
+  read -p "Continue (y/n)?" choice
+  case $choice in
+    Y|y ) return 0;;
+    * ) return 1;;
+  esac
+}
+
+if [[ "$CURR_BRANCH" == "master" ]]; then
+  VERSION_CHANGE="patch"
+    if ! verify; then
+    echo "Version update cancelled!"
+    exit 1;
+  fi
+elif [[ "$CURR_BRANCH" == "staging" ]]; then
+  VERSION_CHANGE="prerelease"
+  if ! verify; then
+    echo "Version update cancelled!"
+    exit 1;
+  fi
+else
+  echo "Current Branch not supported: $CURR_BRANCH"
+  exit 0;
+fi
+
+# Update version based on branch
+NEW_VERSION=$(npm version $VERSION_CHANGE)
+
+# Commit updated files to git
+PARENT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+git add "$(dirname "$0")/../package.json"
+git add "$(dirname "$0")/../package-lock.json"
+git commit -m "Pushed New Version: $VERSION_CHANGE [ci skip]"
+git push origin $CURR_BRANCH
+
+# Update git tags
+git tag "$NEW_VERSION"
+git push --tags
+
+# Run release script
+npm run build 
+npm publish build --tag latest


### PR DESCRIPTION
## Description
Added a script to perform the tasks needed to update and release a new version of the UI

## Notes
The steps include:
1) Validate the branch (can only be run on staging or master)
2) Update the npm version
3) Push updated package files to git
4) Tag Commit with new version number
5) Build the local files
6) Publish the build to npm

## Where to Start
packages/riipen-ui/scripts/update_version.sh