### PR TITLE
[PLT-5265] Popover, Tooltip improvements

### DIFF
--- a/packages/riipen-ui/src/components/Popover.jsx
+++ b/packages/riipen-ui/src/components/Popover.jsx
@@ -40,7 +40,7 @@ class Popover extends React.Component {
      * Whether the popover should be closed when its closest scrollable parent is scrolled.
      * [Default] true
      */
-    closeWhenParentScrolled: PropTypes.bool,
+    closeOnScrolled: PropTypes.bool,
 
     /**
      * The type of element to use at the root
@@ -65,7 +65,7 @@ class Popover extends React.Component {
     /**
      * Function call to handle keydown events,
      */
-    handleKeyDown: PropTypes.func,
+    onKeyDown: PropTypes.func,
 
     /**
      * Whether to keep the popout on screen when the anchor element scrolls off
@@ -95,7 +95,7 @@ class Popover extends React.Component {
   };
 
   static defaultProps = {
-    closeWhenParentScrolled: true,
+    closeOnScrolled: true,
     component: "span",
     fullWidth: false,
     isOpen: false,
@@ -283,35 +283,27 @@ class Popover extends React.Component {
   };
 
   manageScrollableParentEventListeners(remove = true) {
-    const { anchorEl, closeWhenParentScrolled } = this.props;
+    const { anchorEl, closeOnScrolled } = this.props;
     if (anchorEl) {
       const closestScrollableParent = getClosestScrollableParent(anchorEl);
       if (closestScrollableParent) {
         if (remove) {
           closestScrollableParent.removeEventListener(
             "resize",
-            closeWhenParentScrolled
-              ? this.handleClose
-              : this.positionChangeEventHandler
+            closeOnScrolled ? this.handleClose : this.positionChangeEventHandler
           );
           closestScrollableParent.removeEventListener(
             "scroll",
-            closeWhenParentScrolled
-              ? this.handleClose
-              : this.positionChangeEventHandler
+            closeOnScrolled ? this.handleClose : this.positionChangeEventHandler
           );
         } else {
           closestScrollableParent.addEventListener(
             "resize",
-            closeWhenParentScrolled
-              ? this.handleClose
-              : this.positionChangeEventHandler
+            closeOnScrolled ? this.handleClose : this.positionChangeEventHandler
           );
           closestScrollableParent.addEventListener(
             "scroll",
-            closeWhenParentScrolled
-              ? this.handleClose
-              : this.positionChangeEventHandler
+            closeOnScrolled ? this.handleClose : this.positionChangeEventHandler
           );
         }
       }
@@ -347,11 +339,11 @@ class Popover extends React.Component {
       this.handleClose();
     } else if (event.type === "keydown" && event.key === "Escape") {
       this.handleClose();
-    } else if (event.type === "keydown" && this.props.handleKeyDown) {
+    } else if (event.type === "keydown" && this.props.onKeyDown) {
       // stop this event from triggering other keydown listeners
       event.stopImmediatePropagation();
 
-      this.props.handleKeyDown(event);
+      this.props.onKeyDown(event);
     }
   };
 

--- a/packages/riipen-ui/src/components/Popover.jsx
+++ b/packages/riipen-ui/src/components/Popover.jsx
@@ -9,6 +9,7 @@ import {
   getDocument,
   getOffsetLeft,
   getOffsetTop,
+  getClosestScrollableParent,
   debounce
 } from "../utils";
 import withClasses from "../utils/withClasses";
@@ -36,6 +37,12 @@ class Popover extends React.Component {
     classes: PropTypes.array,
 
     /**
+     * Whether the popover should be closed when its closest scrollable parent is scrolled.
+     * [Default] true
+     */
+    closeWhenParentScrolled: PropTypes.bool,
+
+    /**
      * The type of element to use at the root
      */
     component: PropTypes.string,
@@ -54,6 +61,11 @@ class Popover extends React.Component {
      * Whether the popover should be displayed
      */
     isOpen: PropTypes.bool,
+
+    /**
+     * Function call to handle keydown events,
+     */
+    handleKeyDown: PropTypes.func,
 
     /**
      * Whether to keep the popout on screen when the anchor element scrolls off
@@ -83,9 +95,10 @@ class Popover extends React.Component {
   };
 
   static defaultProps = {
+    closeWhenParentScrolled: true,
     component: "span",
     fullWidth: false,
-    isOpen: true,
+    isOpen: false,
     lockScroll: true,
     marginThreshold: 16,
     styles: {}
@@ -116,6 +129,10 @@ class Popover extends React.Component {
     window.addEventListener("mousedown", this.handleCloseEvent);
     window.addEventListener("keydown", this.handleCloseEvent);
 
+    if (anchorEl) {
+      this.manageScrollableParentEventListeners(false);
+    }
+
     if (anchorEl && lockScroll) {
       this.lockParentScroll();
     }
@@ -126,7 +143,12 @@ class Popover extends React.Component {
   componentDidUpdate(prevProps) {
     const anchorChange =
       prevProps.anchorEl === null && this.props.anchorEl !== null;
-    const openChange = !prevProps.isOpen && this.props.isOpen;
+
+    /* need to NOT check that previous prop was !isOpen
+     * in order to cause positioning of popover to be correct
+     * when it is opened by a controlled Tooltip being opened
+     */
+    const openChange = this.props.isOpen;
     const anchorPositionChange = !(
       prevProps.anchorPosition === this.props.anchorPosition
     );
@@ -134,13 +156,19 @@ class Popover extends React.Component {
       prevProps.contentPosition === this.props.contentPosition
     );
 
+    if (anchorChange) {
+      // add event listeners
+      this.manageScrollableParentEventListeners(false);
+    }
+
     if (
       anchorChange ||
       openChange ||
       contentPositionChange ||
       anchorPositionChange
     ) {
-      this.setPositioningStyle();
+      // need to use requestAnimationFrame in order for popover to get proper position on first open
+      window.requestAnimationFrame(this.setPositioningStyle);
     }
   }
 
@@ -150,6 +178,8 @@ class Popover extends React.Component {
     window.removeEventListener("scroll", this.positionChangeEventHandler);
     window.removeEventListener("mousedown", this.handleCloseEvent);
     window.removeEventListener("keydown", this.handleCloseEvent);
+
+    this.manageScrollableParentEventListeners(true);
 
     if (anchorEl && lockScroll) {
       this.resetParentScroll();
@@ -163,6 +193,7 @@ class Popover extends React.Component {
 
   setPositioningStyle = () => {
     const contentRef = this.contentRef.current;
+
     const {
       anchorPosition = {
         vertical: "top",
@@ -251,6 +282,42 @@ class Popover extends React.Component {
     );
   };
 
+  manageScrollableParentEventListeners(remove = true) {
+    const { anchorEl, closeWhenParentScrolled } = this.props;
+    if (anchorEl) {
+      const closestScrollableParent = getClosestScrollableParent(anchorEl);
+      if (closestScrollableParent) {
+        if (remove) {
+          closestScrollableParent.removeEventListener(
+            "resize",
+            closeWhenParentScrolled
+              ? this.handleClose
+              : this.positionChangeEventHandler
+          );
+          closestScrollableParent.removeEventListener(
+            "scroll",
+            closeWhenParentScrolled
+              ? this.handleClose
+              : this.positionChangeEventHandler
+          );
+        } else {
+          closestScrollableParent.addEventListener(
+            "resize",
+            closeWhenParentScrolled
+              ? this.handleClose
+              : this.positionChangeEventHandler
+          );
+          closestScrollableParent.addEventListener(
+            "scroll",
+            closeWhenParentScrolled
+              ? this.handleClose
+              : this.positionChangeEventHandler
+          );
+        }
+      }
+    }
+  }
+
   isDecendant(parent, child) {
     const node = child.parentNode;
     if (node == null) {
@@ -280,6 +347,11 @@ class Popover extends React.Component {
       this.handleClose();
     } else if (event.type === "keydown" && event.key === "Escape") {
       this.handleClose();
+    } else if (event.type === "keydown" && this.props.handleKeyDown) {
+      // stop this event from triggering other keydown listeners
+      event.stopImmediatePropagation();
+
+      this.props.handleKeyDown(event);
     }
   };
 

--- a/packages/riipen-ui/src/components/Tooltip.jsx
+++ b/packages/riipen-ui/src/components/Tooltip.jsx
@@ -43,9 +43,21 @@ class Tooltip extends React.Component {
     component: PropTypes.elementType,
 
     /**
+     * Function to call on tooltip keydown.
+     */
+    handleKeyDown: PropTypes.func,
+
+    /**
      * Whether tooltip should display on hover.
      */
     hover: PropTypes.bool,
+
+    /**
+     * How the open/close state will be determined:
+     * [Default] false: by this component's state,
+     * true: by this component's props.
+     */
+    isControlledByProps: PropTypes.bool,
 
     /**
      * Function to call on tooltip close.
@@ -56,6 +68,13 @@ class Tooltip extends React.Component {
      * Function to call on tooltip open.
      */
     onOpen: PropTypes.func,
+
+    /**
+     * Whether the popover should be open/shown.
+     * Only used when props.isControlledByProps is true
+     * [Default] false
+     */
+    open: PropTypes.bool,
 
     /**
      * Where to display the tooltip in relation to element.
@@ -88,6 +107,8 @@ class Tooltip extends React.Component {
     color: "default",
     component: "div",
     hover: true,
+    isControlledByProps: false,
+    open: false,
     position: "bottom-center",
     size: "small"
   };
@@ -398,7 +419,9 @@ class Tooltip extends React.Component {
     const { open } = this.state;
 
     const callback = !open ? this.props.onOpen : this.props.onClose;
+
     this.blur();
+
     this.setState(
       {
         open: !open
@@ -415,6 +438,7 @@ class Tooltip extends React.Component {
 
   handleClose = () => {
     this.blur();
+
     this.setState(
       {
         open: false
@@ -424,8 +448,18 @@ class Tooltip extends React.Component {
   };
 
   renderPopover = () => {
-    const { classes, color, position, size, tooltip, ...other } = this.props;
-    const { open } = this.state;
+    const {
+      classes,
+      color,
+      handleKeyDown,
+      isControlledByProps,
+      position,
+      size,
+      tooltip,
+      ...other
+    } = this.props;
+
+    const { open } = isControlledByProps ? this.props : this.state;
 
     const linkedStyles = this.getLinkedStyles();
 
@@ -461,6 +495,7 @@ class Tooltip extends React.Component {
           horizontal: contentHorizontal,
           vertical: contentVertical
         }}
+        handleKeyDown={handleKeyDown}
         anchorEl={this.tooltipRootRef.current}
         isOpen={open}
         keepOnScreen
@@ -482,7 +517,7 @@ class Tooltip extends React.Component {
         <Component
           ref={this.tooltipRootRef}
           onClick={click ? this.clickCallback : undefined}
-          onMouseOver={hover ? this.handleOpen : undefined}
+          onMouseEnter={hover ? this.handleOpen : undefined}
           onMouseLeave={hover ? this.handleClose : undefined}
         >
           {children}

--- a/packages/riipen-ui/src/components/Tooltip.jsx
+++ b/packages/riipen-ui/src/components/Tooltip.jsx
@@ -45,7 +45,7 @@ class Tooltip extends React.Component {
     /**
      * Function to call on tooltip keydown.
      */
-    handleKeyDown: PropTypes.func,
+    onKeyDown: PropTypes.func,
 
     /**
      * Whether tooltip should display on hover.
@@ -451,7 +451,7 @@ class Tooltip extends React.Component {
     const {
       classes,
       color,
-      handleKeyDown,
+      onKeyDown,
       isControlledByProps,
       position,
       size,
@@ -495,7 +495,7 @@ class Tooltip extends React.Component {
           horizontal: contentHorizontal,
           vertical: contentVertical
         }}
-        handleKeyDown={handleKeyDown}
+        onKeyDown={onKeyDown}
         anchorEl={this.tooltipRootRef.current}
         isOpen={open}
         keepOnScreen

--- a/packages/riipen-ui/src/utils/container.js
+++ b/packages/riipen-ui/src/utils/container.js
@@ -17,4 +17,22 @@ export function getContainer(node) {
   return doc.defaultView || window;
 }
 
+/**
+ * Get closest parent that is scrollable
+ * @param {element} node - An element in the DOM
+ * @return {string} The closest scrollable parent view element that contains the element
+ */
+export function getClosestScrollableParent(node) {
+  if (!node || node === getDocument(node)) {
+    return window;
+  }
+  const overflowY = window.getComputedStyle(node).overflowY;
+  const isScrollable = overflowY !== "visible" && overflowY !== "hidden";
+
+  if (isScrollable) {
+    return node;
+  }
+  return getClosestScrollableParent(node.parentElement);
+}
+
 export default { getDocument, getContainer };

--- a/packages/riipen-ui/src/utils/index.js
+++ b/packages/riipen-ui/src/utils/index.js
@@ -1,3 +1,7 @@
 export { default as debounce } from "./debounce";
-export { getContainer, getDocument } from "./container";
+export {
+  getContainer,
+  getDocument,
+  getClosestScrollableParent
+} from "./container";
 export { getOffsetLeft, getOffsetTop } from "./offset";


### PR DESCRIPTION
[[PLT-5265]](https://riipen.atlassian.net/browse/PLT-5265)

## Description
* Fix bug with `Popover` where initial position would be off by (properContentRectWidth/2 - 21px)
* Add `keydown` handler to `Popover` / `Tooltip`
* Add `closeOnParentScroll` prop to `Popover` --> closes Popover when scrollable Parent container is scrolled
* Add `getClosestScrollableParent` util
* Add ability for `Tooltip` open/close state to be controlled by props

## Notes
* Required for https://github.com/riipen/web/pull/2585
## Screenshots

## Where to Start
