### PR TITLE
Students/Header Popover issue fix

### DIFF
--- a/packages/riipen-ui/src/components/Popover.jsx
+++ b/packages/riipen-ui/src/components/Popover.jsx
@@ -98,7 +98,7 @@ class Popover extends React.Component {
     closeOnScrolled: true,
     component: "span",
     fullWidth: false,
-    isOpen: false,
+    isOpen: true,
     lockScroll: true,
     marginThreshold: 16,
     styles: {}


### PR DESCRIPTION
## Description
* change default `isOpen` prop to `true`, fixes Invite Students /  `Students/Header` popover not appearing issue
## Notes

## Screenshots

## Where to Start
