### PR TITLE
Allow tabs to be forced to display active

### DIFF
--- a/packages/riipen-ui-docs/src/pages/components/tabs/Forced.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/tabs/Forced.jsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+import Tabs from "@riipen-ui/components/Tabs";
+import Tab from "@riipen-ui/components/Tab";
+
+export default function Forced() {
+  const style = {
+    backgroundColor: "#fff",
+    width: "200px"
+  };
+
+  const [state, setState] = React.useState({
+    value: "one"
+  });
+
+  const handleChange = (e, value) => {
+    setState({ ...state, value });
+  };
+
+  return (
+    <div style={style}>
+      <Tabs onChange={handleChange} orientation="vertical" value={state.value}>
+        <Tab label="Item one" value="one" />
+        <Tab label="Item two" value="two" />
+        <Tab label="Item three" value="three" active />
+      </Tabs>
+    </div>
+  );
+}

--- a/packages/riipen-ui-docs/src/pages/components/tabs/Forced.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/tabs/Forced.jsx
@@ -4,26 +4,54 @@ import Tabs from "@riipen-ui/components/Tabs";
 import Tab from "@riipen-ui/components/Tab";
 
 export default function Forced() {
-  const style = {
+  const vertical = {
     backgroundColor: "#fff",
-    width: "200px"
+    width: "200px",
+    display: "inline-block"
+  };
+
+  const horizontal = {
+    backgroundColor: "#fff",
+    display: "inline-block",
+    margin: "0 40px"
   };
 
   const [state, setState] = React.useState({
-    value: "one"
+    value: "one/one"
   });
 
   const handleChange = (e, value) => {
     setState({ ...state, value });
   };
 
+  const firstPart = state.value.split("/")[0];
+
   return (
-    <div style={style}>
-      <Tabs onChange={handleChange} orientation="vertical" value={state.value}>
-        <Tab label="Item one" value="one" />
-        <Tab label="Item two" value="two" />
-        <Tab label="Item three" value="three" active />
-      </Tabs>
+    <div>
+      <div style={vertical}>
+        <Tabs
+          onChange={handleChange}
+          orientation="vertical"
+          value={state.value}
+        >
+          <Tab label="Item one" value="one" active={firstPart === "one"} />
+          <Tab label="Item two" value="two" active={firstPart === "two"} />
+        </Tabs>
+      </div>
+      <div style={horizontal}>
+        {firstPart === "one" && (
+          <Tabs onChange={handleChange} value={state.value}>
+            <Tab label="Item one one" value="one/one" />
+            <Tab label="Item one two" value="one/two" />
+          </Tabs>
+        )}
+        {firstPart === "two" && (
+          <Tabs onChange={handleChange} value={state.value}>
+            <Tab label="Item two one" value="two/one" />
+            <Tab label="Item two two" value="two/two" />
+          </Tabs>
+        )}
+      </div>
     </div>
   );
 }

--- a/packages/riipen-ui-docs/src/pages/components/tabs/Forced.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/tabs/Forced.jsx
@@ -4,54 +4,26 @@ import Tabs from "@riipen-ui/components/Tabs";
 import Tab from "@riipen-ui/components/Tab";
 
 export default function Forced() {
-  const vertical = {
+  const style = {
     backgroundColor: "#fff",
-    width: "200px",
-    display: "inline-block"
-  };
-
-  const horizontal = {
-    backgroundColor: "#fff",
-    display: "inline-block",
-    margin: "0 40px"
+    width: "200px"
   };
 
   const [state, setState] = React.useState({
-    value: "one/one"
+    value: "one"
   });
 
   const handleChange = (e, value) => {
     setState({ ...state, value });
   };
 
-  const firstPart = state.value.split("/")[0];
-
   return (
-    <div>
-      <div style={vertical}>
-        <Tabs
-          onChange={handleChange}
-          orientation="vertical"
-          value={state.value}
-        >
-          <Tab label="Item one" value="one" active={firstPart === "one"} />
-          <Tab label="Item two" value="two" active={firstPart === "two"} />
-        </Tabs>
-      </div>
-      <div style={horizontal}>
-        {firstPart === "one" && (
-          <Tabs onChange={handleChange} value={state.value}>
-            <Tab label="Item one one" value="one/one" />
-            <Tab label="Item one two" value="one/two" />
-          </Tabs>
-        )}
-        {firstPart === "two" && (
-          <Tabs onChange={handleChange} value={state.value}>
-            <Tab label="Item two one" value="two/one" />
-            <Tab label="Item two two" value="two/two" />
-          </Tabs>
-        )}
-      </div>
+    <div style={style}>
+      <Tabs onChange={handleChange} orientation="vertical" value={state.value}>
+        <Tab label="Item one" value="one" />
+        <Tab label="Item two" value="two" />
+        <Tab label="Item three" value="three" displayActive />
+      </Tabs>
     </div>
   );
 }

--- a/packages/riipen-ui-docs/src/pages/components/tabs/tabs.md
+++ b/packages/riipen-ui-docs/src/pages/components/tabs/tabs.md
@@ -35,3 +35,9 @@ Tab labels may be either all icons or all text.
 Tabs can be displayed vertically be setting the `orientation` prop.
 
 {{"demo": "pages/components/tabs/Vertical.js"}}
+
+## Forcing Active Display
+
+Tabs can be forced to display active with the `active` tab prop.
+
+{{"demo": "pages/components/tabs/Forced.js"}}

--- a/packages/riipen-ui-docs/src/pages/components/tabs/tabs.md
+++ b/packages/riipen-ui-docs/src/pages/components/tabs/tabs.md
@@ -38,6 +38,6 @@ Tabs can be displayed vertically be setting the `orientation` prop.
 
 ## Forcing Active Display
 
-Tabs can be forced to display active with the `active` tab prop.
+Tabs can be forced to display active with the `displayActive` tab prop.
 
 {{"demo": "pages/components/tabs/Forced.js"}}

--- a/packages/riipen-ui/package.json
+++ b/packages/riipen-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riipen-ui",
-  "version": "0.0.120",
+  "version": "0.0.121",
   "private": false,
   "author": {
     "name": "Riipen",

--- a/packages/riipen-ui/src/components/Tab.jsx
+++ b/packages/riipen-ui/src/components/Tab.jsx
@@ -10,6 +10,7 @@ const Tab = props => {
     classes,
     color,
     disabled,
+    displayActive,
     fullWidth,
     icon: Icon,
     label,
@@ -45,8 +46,8 @@ const Tab = props => {
 
   const className = clsx(
     "root",
-    active ? `${color}-active` : null,
-    active ? `${orientation}-active` : null,
+    active || displayActive ? `${color}-active` : null,
+    active || displayActive ? `${orientation}-active` : null,
     color,
     disabled ? "disabled" : null,
     focusVisible ? "focusVisible" : null,
@@ -179,6 +180,11 @@ Tab.propTypes = {
    * If `true`, the tab will be disabled.
    */
   disabled: PropTypes.bool,
+
+  /**
+   * If `true` will force the tab to be displayed active
+   */
+  displayActive: PropTypes.bool,
 
   /**
    * If `true`, will make the tab grow to use all the available space,

--- a/packages/riipen-ui/src/components/Tabs.jsx
+++ b/packages/riipen-ui/src/components/Tabs.jsx
@@ -86,8 +86,10 @@ class Tabs extends React.Component {
     const childrenWithProps = React.Children.map(children, child => {
       if (!child) return null;
 
+      const active = child.props.active || child.props.value === value;
+
       return React.cloneElement(child, {
-        active: child.props.value === value,
+        active,
         color,
         fullWidth: variant === "fullWidth",
         onClick: this.handleChange,


### PR DESCRIPTION
## Description

## Notes
Using this for nested tabs where the values dont always match (such as using window.location for the value)

## Screenshots
<img width="990" alt="Screen Shot 2020-07-31 at 11 10 13 AM" src="https://user-images.githubusercontent.com/1365762/89064218-7003d380-d31e-11ea-80f0-62c1d4441454.png">

## Where to Start
