### PR TITLE
Import specific fontawesome icons instead of all

### DIFF
--- a/packages/riipen-ui/src/components/EditorBlockStyleControls.jsx
+++ b/packages/riipen-ui/src/components/EditorBlockStyleControls.jsx
@@ -3,11 +3,9 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {
-  faListOl,
-  faListUl,
-  faQuoteLeft
-} from "@fortawesome/free-solid-svg-icons";
+import faListOl from "@fortawesome/free-solid-svg-icons/faListOl";
+import faListUl from "@fortawesome/free-solid-svg-icons/faListUl";
+import faQuoteLeft from "@fortawesome/free-solid-svg-icons/faQuoteLeft";
 
 import EditorControlButton from "./EditorControlButton";
 

--- a/packages/riipen-ui/src/components/EditorInlineStyleControls.jsx
+++ b/packages/riipen-ui/src/components/EditorInlineStyleControls.jsx
@@ -3,11 +3,9 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {
-  faBold,
-  faItalic,
-  faUnderline
-} from "@fortawesome/free-solid-svg-icons";
+import faBold from "@fortawesome/free-solid-svg-icons/faBold";
+import faItalic from "@fortawesome/free-solid-svg-icons/faItalic";
+import faUnderline from "@fortawesome/free-solid-svg-icons/faUnderline";
 
 import EditorControlButton from "./EditorControlButton";
 


### PR DESCRIPTION
https://github.com/riipen/developer-web/pull/71

## Description
This makes it so that only the icons used are imported instead of the whole library (700kb parsed) 🎉 .

## Notes
This will probably help out platform too because hopefully we are using the proper import style everywhere on that project.