### PR TITLE
Add muted typography colour

### DIFF
--- a/packages/riipen-ui-docs/src/pages/components/typography/Component.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/typography/Component.jsx
@@ -46,6 +46,12 @@ export default function Component() {
       <Typography variant="caption" display="block" gutter>
         caption text
       </Typography>
+      <Typography color="primary">primary color</Typography>
+      <Typography color="secondary">secondary color</Typography>
+      <Typography color="tertiary">tertiary color</Typography>
+      <Typography color="positive">positive color</Typography>
+      <Typography color="negative">negative color</Typography>
+      <Typography color="muted">muted color</Typography>
     </div>
   );
 }

--- a/packages/riipen-ui/package.json
+++ b/packages/riipen-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riipen-ui",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": false,
   "author": {
     "name": "Riipen",

--- a/packages/riipen-ui/src/components/Typography.jsx
+++ b/packages/riipen-ui/src/components/Typography.jsx
@@ -42,7 +42,8 @@ class Typography extends React.Component {
       "secondary",
       "tertiary",
       "positive",
-      "negative"
+      "negative",
+      "muted"
     ]),
 
     /**
@@ -169,6 +170,9 @@ class Typography extends React.Component {
           }
           .color-negative {
             color: ${theme.palette.negative.main};
+          }
+          .color-muted {
+            color: ${theme.palette.text.secondary};
           }
 
           .align-center {


### PR DESCRIPTION
## Description
Add muted typography colour to typography.  Update example.

## Notes

## Screenshots
![Screenshot_2020-09-03 Typography Riipen UI](https://user-images.githubusercontent.com/10818279/92157481-50f5d700-eddf-11ea-9625-ccf3e9b3d060.png)


## Where to Start
packages/riipen-ui/src/components/Typography.jsx 