### PR TITLE
Accordion

### DIFF
--- a/packages/riipen-ui-docs/pages/components/accordion.jsx
+++ b/packages/riipen-ui-docs/pages/components/accordion.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+import MarkdownPage from "src/modules/components/MarkdownPage";
+
+const req = require.context(
+  "src/pages/components/accordion",
+  false,
+  /\.(md|js|jsx)$/
+);
+
+const reqSource = require.context(
+  "!raw-loader!../../src/pages/components/accordion",
+  false,
+  /\.(js|jsx)$/
+);
+
+export default function Page() {
+  return (
+    <MarkdownPage
+      path="pages/components/accordion"
+      req={req}
+      reqSource={reqSource}
+      title="Accordion"
+    />
+  );
+}

--- a/packages/riipen-ui-docs/src/modules/components/Menu.jsx
+++ b/packages/riipen-ui-docs/src/modules/components/Menu.jsx
@@ -78,7 +78,7 @@ const Menu = () => {
           font-weight: ${theme.typography.fontWeight.regular};
           list-style-type: none;
           margin: 0;
-          padding-left: 10px;
+          padding-left: ${theme.spacing(2)}px;
         }
         li {
           padding: ${theme.spacing(1)}px;

--- a/packages/riipen-ui-docs/src/modules/components/Menu.jsx
+++ b/packages/riipen-ui-docs/src/modules/components/Menu.jsx
@@ -1,15 +1,21 @@
 import React from "react";
 
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faChevronDown } from "@fortawesome/free-solid-svg-icons";
+
+import Accordion from "riipen-ui/components/Accordion";
+import AccordionDetails from "riipen-ui/components/AccordionDetails";
+import AccordionSummary from "riipen-ui/components/AccordionSummary";
+import ThemeContext from "riipen-ui/styles/ThemeContext";
+
 import Link from "src/modules/components/Link";
 import pages from "src/pages";
 
-import ThemeContext from "riipen-ui/styles/ThemeContext";
+const Menu = () => {
+  const theme = React.useContext(ThemeContext);
 
-class Menu extends React.Component {
-  getLinks = (parent, links) => {
+  const getLinks = (parent, links) => {
     const returnLinks = links || [];
-
-    const theme = this.context;
 
     return parent.children.map((child, j) => {
       const listItem = (
@@ -33,51 +39,53 @@ class Menu extends React.Component {
       return (
         <React.Fragment key={`${parent.name}-list-${j}`}>
           {listItem}
-          <ul>{this.getLinks(child, returnLinks)}</ul>
+          <ul>{getLinks(child, returnLinks)}</ul>
         </React.Fragment>
       );
     });
   };
 
-  static contextType = ThemeContext;
+  const Icon = <FontAwesomeIcon icon={faChevronDown} />;
 
-  render() {
-    const theme = this.context;
-
-    return (
-      <div>
-        <ul>
-          {pages.map((parent, i) => (
-            <li key={i}>
-              {parent.name}
-              <ul>{this.getLinks(parent)}</ul>
-            </li>
-          ))}
-        </ul>
-        <style jsx>{`
-          div {
-            font-family: ${theme.typography.fontFamily};
-            width: 250px;
-          }
-          ul {
-            font-weight: ${theme.typography.fontWeight.bold};
-            list-style-type: none;
-            margin: 0;
-            padding: 0;
-          }
-          ul ul {
-            font-weight: ${theme.typography.fontWeight.regular};
-            list-style-type: none;
-            margin: 0;
-            padding-left: 10px;
-          }
-          li {
-            padding: ${theme.spacing(1)}px;
-          }
-        `}</style>
-      </div>
-    );
-  }
-}
+  return (
+    <div>
+      <ul>
+        {pages.map((parent, i) => (
+          <li key={i}>
+            <Accordion {...parent.props}>
+              <AccordionSummary icon={Icon} iconProps={{ size: "small" }}>
+                {parent.name}
+              </AccordionSummary>
+              <AccordionDetails>
+                <ul>{getLinks(parent)}</ul>
+              </AccordionDetails>
+            </Accordion>
+          </li>
+        ))}
+      </ul>
+      <style jsx>{`
+        div {
+          font-family: ${theme.typography.fontFamily};
+          width: 250px;
+        }
+        ul {
+          font-weight: ${theme.typography.fontWeight.bold};
+          list-style-type: none;
+          margin: 0;
+          padding: 0;
+        }
+        ul ul {
+          font-weight: ${theme.typography.fontWeight.regular};
+          list-style-type: none;
+          margin: 0;
+          padding-left: 10px;
+        }
+        li {
+          padding: ${theme.spacing(1)}px;
+        }
+      `}</style>
+    </div>
+  );
+};
 
 export default Menu;

--- a/packages/riipen-ui-docs/src/pages.js
+++ b/packages/riipen-ui-docs/src/pages.js
@@ -1,6 +1,9 @@
 const pages = [
   {
     name: "Getting Started",
+    props: {
+      defaultExpanded: true
+    },
     children: [
       {
         name: "Installation",
@@ -14,7 +17,14 @@ const pages = [
   },
   {
     name: "Components",
+    props: {
+      defaultExpanded: true
+    },
     children: [
+      {
+        name: "Accordion",
+        pathname: "/components/accordion"
+      },
       {
         name: "App Bar",
         pathname: "/components/app-bar"
@@ -131,6 +141,7 @@ const pages = [
   },
   {
     name: "API",
+    props: {},
     children: [
       {
         name: "App Bar",
@@ -256,6 +267,7 @@ const pages = [
   },
   {
     name: "Guides",
+    props: {},
     children: [
       {
         name: "Bundle Size",

--- a/packages/riipen-ui-docs/src/pages/components/accordion/Simple.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/accordion/Simple.jsx
@@ -1,0 +1,69 @@
+import React from "react";
+
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faChevronDown } from "@fortawesome/free-solid-svg-icons";
+
+import Accordion from "riipen-ui/components/Accordion";
+import AccordionDetails from "riipen-ui/components/AccordionDetails";
+import AccordionSummary from "riipen-ui/components/AccordionSummary";
+import Typography from "riipen-ui/components/Typography";
+
+export default function Simple() {
+  const style = {
+    marginBottom: "10px"
+  };
+
+  const Icon = <FontAwesomeIcon icon={faChevronDown} />;
+
+  return (
+    <div>
+      <Accordion>
+        <AccordionSummary icon={Icon} iconProps={{ size: "small" }}>
+          <Typography>Accordion With Icon</Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          <Typography>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+            malesuada lacus ex, sit amet blandit leo lobortis eget.
+          </Typography>
+        </AccordionDetails>
+      </Accordion>
+      <div style={style} />
+      <Accordion>
+        <AccordionSummary>
+          <Typography>Accordion Without Icon</Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          <Typography>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+            malesuada lacus ex, sit amet blandit leo lobortis eget.
+          </Typography>
+        </AccordionDetails>
+      </Accordion>
+      <div style={style} />
+      <Accordion disabled>
+        <AccordionSummary icon={Icon} iconProps={{ size: "small" }}>
+          <Typography>Disabled Accordion</Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          <Typography>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+            malesuada lacus ex, sit amet blandit leo lobortis eget.
+          </Typography>
+        </AccordionDetails>
+      </Accordion>
+      <div style={style} />
+      <Accordion defaultExpanded>
+        <AccordionSummary icon={Icon} iconProps={{ size: "small" }}>
+          <Typography>Default Expanded</Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          <Typography>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+            malesuada lacus ex, sit amet blandit leo lobortis eget.
+          </Typography>
+        </AccordionDetails>
+      </Accordion>
+    </div>
+  );
+}

--- a/packages/riipen-ui-docs/src/pages/components/accordion/accordion.md
+++ b/packages/riipen-ui-docs/src/pages/components/accordion/accordion.md
@@ -1,0 +1,20 @@
+# Accordion
+
+<p class="description">Accordions contain creation flows and allow lightweight editing of an element.</p>
+
+An accordion is a lightweight container that may either stand alone or be connected to a larger surface, 
+such as a card.
+
+## Simple accordion
+
+{{"demo": "pages/components/accordion/Simple.js"}}
+
+## Performance
+
+The content of Accordions is mounted by default even if the accordion is not expanded. This default behavior has server-side rendering and SEO in mind.
+
+## Accessibility
+
+(WAI-ARIA: https://www.w3.org/TR/wai-aria-practices/#accordion)
+
+For optimal accessibility we recommend setting id and aria-controls on the AccordionSummary. The Accordion will derive the necessary aria-labelledby and id for the content region of the accordion.

--- a/packages/riipen-ui/package-lock.json
+++ b/packages/riipen-ui/package-lock.json
@@ -1935,6 +1935,11 @@
         "which": "^2.0.1"
       }
     },
+    "csstype": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
+      "integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag=="
+    },
     "date-fns": {
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
@@ -2079,6 +2084,15 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
+      }
+    },
+    "dom-helpers": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.0.tgz",
+      "integrity": "sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==",
+      "requires": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "draft-convert": {
@@ -4244,6 +4258,17 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "react-transition-group": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
+      "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      }
     },
     "readable-stream": {
       "version": "2.3.7",

--- a/packages/riipen-ui/package.json
+++ b/packages/riipen-ui/package.json
@@ -59,7 +59,8 @@
     "clsx": "1.0.4",
     "draft-convert": "2.1.10",
     "popper.js": "1.16.1",
-    "prop-types": "15.7.2"
+    "prop-types": "15.7.2",
+    "react-transition-group": "^4.4.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.5",

--- a/packages/riipen-ui/src/components/Accordion.jsx
+++ b/packages/riipen-ui/src/components/Accordion.jsx
@@ -11,8 +11,8 @@ const Accordion = props => {
   const {
     children: childrenProp,
     classes,
-    defaultExpanded = false,
-    disabled = false,
+    defaultExpanded,
+    disabled,
     ...other
   } = props;
 

--- a/packages/riipen-ui/src/components/Accordion.jsx
+++ b/packages/riipen-ui/src/components/Accordion.jsx
@@ -1,0 +1,120 @@
+import clsx from "clsx";
+import PropTypes from "prop-types";
+import React from "react";
+
+import ThemeContext from "../styles/ThemeContext";
+
+import AccordionContext from "./AccordionContext";
+import Collapse from "./Collapse";
+
+const Accordion = props => {
+  const {
+    children: childrenProp,
+    classes,
+    defaultExpanded = false,
+    disabled = false,
+    ...other
+  } = props;
+
+  const theme = React.useContext(ThemeContext);
+
+  const [expanded, setExpanded] = React.useState(defaultExpanded);
+
+  const handleChange = React.useCallback(() => {
+    setExpanded(!expanded);
+  }, [expanded, setExpanded]);
+
+  const [summary, ...children] = React.Children.toArray(childrenProp);
+
+  const contextValue = React.useMemo(
+    () => ({ disabled, expanded, toggle: handleChange }),
+    [expanded, disabled, handleChange]
+  );
+
+  return (
+    <div
+      className={clsx(
+        "root",
+        {
+          expanded,
+          disabled
+        },
+        classes
+      )}
+      {...other}
+    >
+      <AccordionContext.Provider value={contextValue}>
+        {summary}
+      </AccordionContext.Provider>
+      <Collapse in={expanded}>
+        <div
+          aria-labelledby={summary.props.id}
+          id={summary.props["aria-controls"]}
+        >
+          {children}
+        </div>
+      </Collapse>
+
+      <style jsx>{`
+        .root {
+          position: relative;
+          transition: ${theme.transitions.create(["margin"])};
+          overflow-anchor: none;
+        }
+        .root:before {
+          position: absolute;
+          left: 0;
+          top: -1;
+          right: 0;
+          height: 1;
+          content: "";
+          opacity: 1;
+          background-color: ${theme.palette.divider};
+          transition: ${theme.transitions.create([
+            "background-color",
+            "opacity"
+          ])};
+        }
+        .root:first-child:before {
+          display: "none";
+        }
+
+        .root.expanded:before {
+          opacity: 0;
+        }
+      `}</style>
+    </div>
+  );
+};
+
+Accordion.propTypes = {
+  /**
+   * The content of the accordion.
+   */
+  children: PropTypes.node.isRequired,
+
+  /**
+   * List of additional classes to apply to this component.
+   */
+  classes: PropTypes.array,
+
+  /**
+   * If `true`, expands the accordion by default.
+   */
+  defaultExpanded: PropTypes.bool,
+
+  /**
+   * If `true`, the accordion will be displayed in a disabled state.
+   */
+  disabled: PropTypes.bool
+};
+
+Accordion.defaultProps = {
+  classes: [],
+  defaultExpanded: false,
+  disabled: false
+};
+
+Accordion.displayName = "Accordion";
+
+export default Accordion;

--- a/packages/riipen-ui/src/components/AccordionContext.jsx
+++ b/packages/riipen-ui/src/components/AccordionContext.jsx
@@ -2,8 +2,6 @@ import React from "react";
 
 const AccordionContext = React.createContext({});
 
-if (process.env.NODE_ENV !== "production") {
-  AccordionContext.displayName = "AccordionContext";
-}
+AccordionContext.displayName = "AccordionContext";
 
 export default AccordionContext;

--- a/packages/riipen-ui/src/components/AccordionContext.jsx
+++ b/packages/riipen-ui/src/components/AccordionContext.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+const AccordionContext = React.createContext({});
+
+if (process.env.NODE_ENV !== "production") {
+  AccordionContext.displayName = "AccordionContext";
+}
+
+export default AccordionContext;

--- a/packages/riipen-ui/src/components/AccordionDetails.jsx
+++ b/packages/riipen-ui/src/components/AccordionDetails.jsx
@@ -29,8 +29,6 @@ AccordionDetails.propTypes = {
   classes: PropTypes.array
 };
 
-AccordionDetails.defaultProps = {};
-
 AccordionDetails.displayName = "AccordionDetails";
 
 export default AccordionDetails;

--- a/packages/riipen-ui/src/components/AccordionDetails.jsx
+++ b/packages/riipen-ui/src/components/AccordionDetails.jsx
@@ -1,0 +1,36 @@
+import clsx from "clsx";
+import PropTypes from "prop-types";
+import React from "react";
+
+const AccordionDetails = props => {
+  const { classes, ...other } = props;
+
+  return (
+    <React.Fragment>
+      <div className={clsx("root", classes)} {...other} />
+      <style jsx>{`
+        .root {
+          display: flex;
+        }
+      `}</style>
+    </React.Fragment>
+  );
+};
+
+AccordionDetails.propTypes = {
+  /**
+   * The content of the accordion details.
+   */
+  children: PropTypes.node,
+
+  /**
+   * List of additional classes to apply to this component.
+   */
+  classes: PropTypes.array
+};
+
+AccordionDetails.defaultProps = {};
+
+AccordionDetails.displayName = "AccordionDetails";
+
+export default AccordionDetails;

--- a/packages/riipen-ui/src/components/AccordionSummary.jsx
+++ b/packages/riipen-ui/src/components/AccordionSummary.jsx
@@ -1,0 +1,149 @@
+import clsx from "clsx";
+import PropTypes from "prop-types";
+import React from "react";
+import css from "styled-jsx/css";
+
+import ThemeContext from "../styles/ThemeContext";
+
+import AccordionContext from "./AccordionContext";
+import ButtonIcon from "./ButtonIcon";
+
+const AccordionSummary = props => {
+  const { children, classes, iconProps = {}, icon, ...other } = props;
+
+  const theme = React.useContext(ThemeContext);
+
+  const [focusedState, setFocusedState] = React.useState(false);
+
+  const getLinkedStyles = () => {
+    return css.resolve`
+      .root {
+        align-items: center;
+        cursor: pointer;
+        display: flex;
+        transition: ${theme.transitions.create([
+          "background-color",
+          "min-height"
+        ])};
+        user-select: none;
+      }
+      .root.disabled {
+        cursor: initial;
+      }
+
+      .content {
+        flex-grow: 1;
+        transition: ${theme.transitions.create(["margin"])};
+      }
+
+      .icon {
+        transform: rotate(0deg);
+        transition: ${theme.transitions.create(["transform"])};
+      }
+      .icon.expanded {
+        transform: rotate(180deg);
+      }
+    `;
+  };
+
+  const handleFocusVisible = () => {
+    setFocusedState(true);
+  };
+
+  const handleBlur = () => {
+    setFocusedState(false);
+  };
+
+  const { disabled = false, expanded, toggle } = React.useContext(
+    AccordionContext
+  );
+
+  const handleClick = event => {
+    if (toggle && !disabled) {
+      toggle(event);
+    }
+  };
+
+  const linkedStyles = getLinkedStyles();
+
+  return (
+    <div
+      disabled={disabled}
+      component="div"
+      aria-expanded={expanded}
+      className={clsx(
+        linkedStyles.className,
+        "root",
+        {
+          disabled,
+          expanded,
+          focused: focusedState
+        },
+        classes
+      )}
+      onClick={handleClick}
+      onFocusVisible={handleFocusVisible}
+      onBlur={handleBlur}
+      {...other}
+    >
+      <div
+        className={clsx(linkedStyles.className, "content", {
+          expanded
+        })}
+      >
+        {children}
+      </div>
+      {icon && (
+        <ButtonIcon
+          component="div"
+          {...iconProps}
+          classes={[
+            clsx(
+              linkedStyles.className,
+              "icon",
+              {
+                expanded
+              },
+              iconProps.classes
+            )
+          ]}
+          disabled={disabled}
+        >
+          {icon}
+        </ButtonIcon>
+      )}
+      {linkedStyles.styles}
+    </div>
+  );
+};
+
+AccordionSummary.propTypes = {
+  /**
+   * The content of the accordion summary.
+   */
+  children: PropTypes.node,
+
+  /**
+   * List of additional classes to apply to this component.
+   */
+  classes: PropTypes.array,
+
+  /**
+   * The icon to display as the expand indicator.
+   */
+  icon: PropTypes.node,
+
+  /**
+   * Props applied to the `ButtonIcon` element wrapping the expand icon.
+   */
+  iconProps: PropTypes.object
+};
+
+AccordionSummary.defaultProps = {
+  iconProps: {},
+  classes: []
+};
+
+AccordionSummary.displayName = "AccordionSummary";
+
+export default AccordionSummary;

--- a/packages/riipen-ui/src/components/AccordionSummary.jsx
+++ b/packages/riipen-ui/src/components/AccordionSummary.jsx
@@ -9,7 +9,7 @@ import AccordionContext from "./AccordionContext";
 import ButtonIcon from "./ButtonIcon";
 
 const AccordionSummary = props => {
-  const { children, classes, iconProps = {}, icon, ...other } = props;
+  const { children, classes, iconProps, icon, ...other } = props;
 
   const theme = React.useContext(ThemeContext);
 
@@ -69,7 +69,6 @@ const AccordionSummary = props => {
   return (
     <div
       disabled={disabled}
-      component="div"
       aria-expanded={expanded}
       className={clsx(
         linkedStyles.className,
@@ -140,8 +139,8 @@ AccordionSummary.propTypes = {
 };
 
 AccordionSummary.defaultProps = {
-  iconProps: {},
-  classes: []
+  classes: [],
+  iconProps: {}
 };
 
 AccordionSummary.displayName = "AccordionSummary";

--- a/packages/riipen-ui/src/components/Collapse.jsx
+++ b/packages/riipen-ui/src/components/Collapse.jsx
@@ -33,7 +33,7 @@ const Collapse = props => {
         overflow: visible;
       }
       .exited {
-        visibility: hidden;
+        height: 0;
       }
     `;
   };
@@ -51,13 +51,15 @@ const Collapse = props => {
   };
 
   const handleEntering = node => {
+    const wrapperSize = getWrapperSize();
+
     if (wrapperRef.current) {
       // After the size is read reset the position back to default
       wrapperRef.current.style.position = "";
     }
 
     node.style.transitionDuration = `${theme.transitions.duration.standard}ms`;
-    node.style.height = `${getWrapperSize()}px`;
+    node.style.height = `${wrapperSize}px`;
   };
 
   const handleEntered = node => {
@@ -69,6 +71,9 @@ const Collapse = props => {
   };
 
   const handleExiting = node => {
+    // For some reason smooth collapse doesn't work unless we call this here
+    getWrapperSize();
+
     node.style.transitionDuration = `${theme.transitions.duration.standard}ms`;
     node.style.height = "0";
   };

--- a/packages/riipen-ui/src/components/Collapse.jsx
+++ b/packages/riipen-ui/src/components/Collapse.jsx
@@ -1,0 +1,142 @@
+import clsx from "clsx";
+import PropTypes from "prop-types";
+import React from "react";
+import { Transition } from "react-transition-group";
+import css from "styled-jsx/css";
+
+import ThemeContext from "../styles/ThemeContext";
+
+const Collapse = props => {
+  const {
+    children,
+    classes,
+    component: Component = "div",
+    in: inProp,
+    ...other
+  } = props;
+
+  const theme = React.useContext(ThemeContext);
+
+  const wrapperRef = React.useRef(null);
+
+  const getLinkedStyles = () => {
+    return css.resolve`
+      .root {
+        height: 0;
+        min-height: 0px;
+        overflow: hidden;
+        transition: ${theme.transitions.create(["height"])};
+      }
+
+      .entered {
+        height: auto;
+        overflow: visible;
+      }
+      .exited {
+        visibility: hidden;
+      }
+    `;
+  };
+
+  const getWrapperSize = () =>
+    wrapperRef.current ? wrapperRef.current.clientHeight : 0;
+
+  const handleEnter = node => {
+    if (wrapperRef.current) {
+      // Set absolute position to get the size of collapsed content
+      wrapperRef.current.style.position = "absolute";
+    }
+
+    node.style.height = "0px";
+  };
+
+  const handleEntering = node => {
+    const wrapperSize = getWrapperSize();
+
+    if (wrapperRef.current) {
+      // After the size is read reset the position back to default
+      wrapperRef.current.style.position = "";
+    }
+
+    node.style.transitionDuration = `${theme.transitions.duration.standard}ms`;
+    node.style.height = `${wrapperSize}px`;
+  };
+
+  const handleEntered = node => {
+    node.style.height = "auto";
+  };
+
+  const handleExit = node => {
+    node.style.height = `${getWrapperSize()}px`;
+  };
+
+  const handleExiting = node => {
+    node.style.transitionDuration = `${theme.transitions.duration.standard}ms`;
+    node.style.height = "0px";
+  };
+
+  const linkedStyles = getLinkedStyles();
+
+  return (
+    <Transition
+      in={inProp}
+      onEnter={handleEnter}
+      onEntered={handleEntered}
+      onEntering={handleEntering}
+      onExit={handleExit}
+      onExiting={handleExiting}
+      timeout={theme.transitions.duration.standard}
+      {...other}
+    >
+      {(state, childProps) => (
+        <Component
+          className={clsx(
+            linkedStyles.className,
+            "root",
+            {
+              entered: state === "entered",
+              exited: state === "exited" && !inProp
+            },
+            classes
+          )}
+          {...childProps}
+        >
+          <div ref={wrapperRef}>{children}</div>
+          {linkedStyles.styles}
+        </Component>
+      )}
+    </Transition>
+  );
+};
+
+Collapse.propTypes = {
+  /**
+   * The content node to be collapsed.
+   */
+  children: PropTypes.node,
+
+  /**
+   * List of additional classes to apply to this component.
+   */
+  classes: PropTypes.array,
+
+  /**
+   * The component used for the root node.
+   * Either a string to use a HTML element or a component.
+   */
+  component: PropTypes.elementType,
+
+  /**
+   * If `true`, the component will transition in.
+   */
+  in: PropTypes.bool
+};
+
+Collapse.defaultProps = {
+  classes: [],
+  component: "div"
+};
+
+Collapse.displayName = "Collapse";
+
+export default Collapse;

--- a/packages/riipen-ui/src/components/Collapse.jsx
+++ b/packages/riipen-ui/src/components/Collapse.jsx
@@ -10,7 +10,7 @@ const Collapse = props => {
   const {
     children,
     classes,
-    component: Component = "div",
+    component: Component,
     in: inProp,
     ...other
   } = props;
@@ -23,7 +23,7 @@ const Collapse = props => {
     return css.resolve`
       .root {
         height: 0;
-        min-height: 0px;
+        min-height: 0;
         overflow: hidden;
         transition: ${theme.transitions.create(["height"])};
       }
@@ -47,19 +47,17 @@ const Collapse = props => {
       wrapperRef.current.style.position = "absolute";
     }
 
-    node.style.height = "0px";
+    node.style.height = "0";
   };
 
   const handleEntering = node => {
-    const wrapperSize = getWrapperSize();
-
     if (wrapperRef.current) {
       // After the size is read reset the position back to default
       wrapperRef.current.style.position = "";
     }
 
     node.style.transitionDuration = `${theme.transitions.duration.standard}ms`;
-    node.style.height = `${wrapperSize}px`;
+    node.style.height = `${getWrapperSize()}px`;
   };
 
   const handleEntered = node => {
@@ -72,7 +70,7 @@ const Collapse = props => {
 
   const handleExiting = node => {
     node.style.transitionDuration = `${theme.transitions.duration.standard}ms`;
-    node.style.height = "0px";
+    node.style.height = "0";
   };
 
   const linkedStyles = getLinkedStyles();

--- a/packages/riipen-ui/src/components/index.js
+++ b/packages/riipen-ui/src/components/index.js
@@ -1,3 +1,6 @@
+export { default as Accordion } from "./Accordion";
+export { default as AccordionDetails } from "./AccordionDetails";
+export { default as AccordionSummary } from "./AccordionSummary";
 export { default as AppBar } from "./AppBar";
 export { default as Avatar } from "./Avatar";
 export { default as Backdrop } from "./Backdrop";

--- a/packages/riipen-ui/src/themes/default.js
+++ b/packages/riipen-ui/src/themes/default.js
@@ -112,6 +112,14 @@ export default {
   },
   spacing: factor => 5 * factor,
   transitions: {
+    create: (properties = [], options = {}) =>
+      properties
+        .map(
+          property =>
+            `${property} ${options.duraction || 300}ms ${options.easing ||
+              "cubic-bezier(0.4, 0, 0.2, 1)"}`
+        )
+        .join(", "),
     duration: {
       shortest: 150,
       shorter: 200,

--- a/packages/riipen-ui/src/themes/default.js
+++ b/packages/riipen-ui/src/themes/default.js
@@ -116,7 +116,7 @@ export default {
       properties
         .map(
           property =>
-            `${property} ${options.duraction || 300}ms ${options.easing ||
+            `${property} ${options.duration || 300}ms ${options.easing ||
               "cubic-bezier(0.4, 0, 0.2, 1)"}`
         )
         .join(", "),


### PR DESCRIPTION
## Description

1. Added an `<Accordion>` component (and all of it's needed sub components
2. Added `react-transition-group` dependency
3. Added accordion documentation page
4. Switched menu in docs pages to use accordion

## Notes

This is largely based off of the Material-UI accordion component https://material-ui.com/components/accordion.

The source code is mostly copy and pate and then removing all the un-needed junk.

## Screenshots

![worst-instrument-ever](https://user-images.githubusercontent.com/1061076/92523938-153f8080-f1d6-11ea-9455-890e52edfb0e.gif)

## Where to Start

Start with the `<Accordion>` component and then maybe look at any sub-components.