### PR TITLE
Add span wrapper around img avatars

### DIFF
--- a/packages/riipen-ui-docs/src/pages/components/avatar/Image.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/avatar/Image.jsx
@@ -14,9 +14,6 @@ export default function Image() {
         size="50px"
         src="/static/images/avatars/jordan-ell.png"
       />
-      <Avatar alt="HE" size="50px">
-        HE
-      </Avatar>
       <span style={style} />
       <Avatar
         alt="Jordan Ell"

--- a/packages/riipen-ui-docs/src/pages/components/avatar/Image.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/avatar/Image.jsx
@@ -14,6 +14,9 @@ export default function Image() {
         size="50px"
         src="/static/images/avatars/jordan-ell.png"
       />
+      <Avatar alt="HE" size="50px">
+        HE
+      </Avatar>
       <span style={style} />
       <Avatar
         alt="Jordan Ell"

--- a/packages/riipen-ui/package.json
+++ b/packages/riipen-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riipen-ui",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": false,
   "author": {
     "name": "Riipen",

--- a/packages/riipen-ui/src/components/Avatar.jsx
+++ b/packages/riipen-ui/src/components/Avatar.jsx
@@ -71,24 +71,21 @@ class Avatar extends React.Component {
 
     return (
       <React.Fragment>
-        {src ? (
-          <span className="image">
+        <span className={className}>
+          {src ? (
             <img alt={alt} src={src} className={className} {...other} />
-          </span>
-        ) : (
-          <span className={className}>{children}</span>
-        )}
+          ) : (
+            <span className="inner">{children}</span>
+          )}
+        </span>
         <style jsx>{`
           .avatar {
-            align-items: center;
             background-color: ${theme.palette.grey[200]};
             border: ${this.getBorderSize()} solid ${theme.palette.common.white};
-            display: inline-flex;
-            flex-shrink: 0;
+            display: inline-block;
             font-family: ${theme.typography.fontFamily};
             font-size: calc(${size} * 0.4);
             height: ${size};
-            justify-content: center;
             line-height: 1;
             overflow: hidden;
             user-select: none;
@@ -99,10 +96,13 @@ class Avatar extends React.Component {
             border-radius: 50%;
           }
 
-          .image {
-            display: block;
-            height: calc(${size} + ${this.getBorderSize()} * 2);
-            width: calc(${size} + ${this.getBorderSize()} * 2);
+          .inner {
+            align-items: center;
+            display: flex;
+            flex-shrink: 0;
+            height: 100%;
+            justify-content: center;
+            width: 100%;
           }
 
           .rounded {

--- a/packages/riipen-ui/src/components/Avatar.jsx
+++ b/packages/riipen-ui/src/components/Avatar.jsx
@@ -71,22 +71,21 @@ class Avatar extends React.Component {
 
     return (
       <React.Fragment>
-        {src ? (
-          <img alt={alt} src={src} className={className} {...other} />
-        ) : (
-          <span className={className}>{children}</span>
-        )}
+        <span className={className}>
+          {src ? (
+            <img alt={alt} src={src} className="image" {...other} />
+          ) : (
+            <span className="inner">{children}</span>
+          )}
+        </span>
         <style jsx>{`
           .avatar {
-            align-items: center;
             background-color: ${theme.palette.grey[200]};
             border: ${this.getBorderSize()} solid ${theme.palette.common.white};
-            display: inline-flex;
-            flex-shrink: 0;
+            display: inline-block;
             font-family: ${theme.typography.fontFamily};
             font-size: calc(${size} * 0.4);
             height: ${size};
-            justify-content: center;
             line-height: 1;
             overflow: hidden;
             user-select: none;
@@ -96,6 +95,21 @@ class Avatar extends React.Component {
           .circle {
             border-radius: 50%;
           }
+
+          .image {
+            height: ${size};
+            width: ${size};
+          }
+
+          .inner {
+            align-items: center;
+            display: flex;
+            flex-shrink: 0;
+            height: 100%;
+            justify-content: center;
+            width: 100%;
+          }
+
           .rounded {
             border-radius: ${theme.shape.borderRadius.md};
           }

--- a/packages/riipen-ui/src/components/Avatar.jsx
+++ b/packages/riipen-ui/src/components/Avatar.jsx
@@ -71,21 +71,22 @@ class Avatar extends React.Component {
 
     return (
       <React.Fragment>
-        <span className={className}>
-          {src ? (
-            <img alt={alt} src={src} className={className} {...other} />
-          ) : (
-            <span className="inner">{children}</span>
-          )}
-        </span>
+        {src ? (
+          <img alt={alt} src={src} className={className} {...other} />
+        ) : (
+          <span className={className}>{children}</span>
+        )}
         <style jsx>{`
           .avatar {
+            align-items: center;
             background-color: ${theme.palette.grey[200]};
             border: ${this.getBorderSize()} solid ${theme.palette.common.white};
-            display: inline-block;
+            display: inline-flex;
+            flex-shrink: 0;
             font-family: ${theme.typography.fontFamily};
             font-size: calc(${size} * 0.4);
             height: ${size};
+            justify-content: center;
             line-height: 1;
             overflow: hidden;
             user-select: none;
@@ -95,16 +96,6 @@ class Avatar extends React.Component {
           .circle {
             border-radius: 50%;
           }
-
-          .inner {
-            align-items: center;
-            display: flex;
-            flex-shrink: 0;
-            height: 100%;
-            justify-content: center;
-            width: 100%;
-          }
-
           .rounded {
             border-radius: ${theme.shape.borderRadius.md};
           }

--- a/packages/riipen-ui/src/components/Avatar.jsx
+++ b/packages/riipen-ui/src/components/Avatar.jsx
@@ -72,7 +72,9 @@ class Avatar extends React.Component {
     return (
       <React.Fragment>
         {src ? (
-          <img alt={alt} src={src} className={className} {...other} />
+          <span className="image">
+            <img alt={alt} src={src} className={className} {...other} />
+          </span>
         ) : (
           <span className={className}>{children}</span>
         )}
@@ -96,6 +98,13 @@ class Avatar extends React.Component {
           .circle {
             border-radius: 50%;
           }
+
+          .image {
+            display: block;
+            height: calc(${size} + ${this.getBorderSize()} * 2);
+            width: calc(${size} + ${this.getBorderSize()} * 2);
+          }
+
           .rounded {
             border-radius: ${theme.shape.borderRadius.md};
           }


### PR DESCRIPTION
## Description
There is currently an issue with the UI kit avatar where if there is an avatar with an image and an avatar with just letters (or other content), they do not display nicely next to each other.  This PR attempts to solve this issue by updating the css in the Avatar component.

Original issue: 
![Screenshot_2020-09-28 Avatar Riipen UI(2)](https://user-images.githubusercontent.com/10818279/94462060-d0bd5a00-016f-11eb-99ad-1c57f53d00cd.png)

## Screenshots
![Screenshot_2020-09-28 Avatar Riipen UI(1)](https://user-images.githubusercontent.com/10818279/94462079-d6b33b00-016f-11eb-8567-f81e39a94ed3.png)

## Where to Start
packages/riipen-ui/src/components/Avatar.jsx 