### PR TITLE
Update avatar image height

### DIFF
--- a/packages/riipen-ui/src/components/Avatar.jsx
+++ b/packages/riipen-ui/src/components/Avatar.jsx
@@ -97,8 +97,8 @@ class Avatar extends React.Component {
           }
 
           .image {
-            height: ${size};
-            width: ${size};
+            height: 100%;
+            width: 100%;
           }
 
           .inner {


### PR DESCRIPTION
## Description
Small update image height so image fits within wrapper span contents.

## Screenshots
![Screenshot_2020-09-29 Avatar Riipen UI(1)](https://user-images.githubusercontent.com/10818279/94597378-590c2f80-0242-11eb-8356-3682e137cef8.png)


## Where to Start
packages/riipen-ui/src/components/Avatar.jsx