### PR TITLE
Add horizontal tab mobile styling

### DIFF
--- a/packages/riipen-ui-docs/src/pages/components/tabs/Breakpoint.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/tabs/Breakpoint.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+import Tabs from "riipen-ui/components/Tabs";
+import Tab from "riipen-ui/components/Tab";
+
+export default function Breakpoint() {
+  const style = {
+    backgroundColor: "#fff"
+  };
+
+  const [state, setState] = React.useState({
+    value: "one"
+  });
+
+  const handleChange = (e, value) => {
+    setState({ ...state, value });
+  };
+
+  return (
+    <div style={style}>
+      <Tabs onChange={handleChange} value={state.value} breakpoint="xl">
+        <Tab label="Item one" value="one" />
+        <Tab label="Item two" value="two" />
+        <Tab label="Item three" value="three" />
+      </Tabs>
+      <Tabs onChange={handleChange} value={state.value} breakpoint="none">
+        <Tab label="Item one" value="one" />
+        <Tab label="Item two" value="two" />
+        <Tab label="Item three" value="three" />
+      </Tabs>
+    </div>
+  );
+}

--- a/packages/riipen-ui-docs/src/pages/components/tabs/tabs.md
+++ b/packages/riipen-ui-docs/src/pages/components/tabs/tabs.md
@@ -36,6 +36,12 @@ Tabs can be displayed vertically be setting the `orientation` prop.
 
 {{"demo": "pages/components/tabs/Vertical.js"}}
 
+## Breakpoints
+
+You can set the breakpoint to display the horizontal tab mobile styling with the `breakpoint` prop.
+
+{{"demo": "pages/components/tabs/Breakpoint.js"}}
+
 ## Forcing Active Display
 
 Tabs can be forced to display active with the `displayActive` tab prop.

--- a/packages/riipen-ui/src/components/Tab.jsx
+++ b/packages/riipen-ui/src/components/Tab.jsx
@@ -7,6 +7,7 @@ import { useIsFocusVisible, withThemeContext } from "../utils";
 const Tab = props => {
   const {
     active,
+    breakpoint,
     classes,
     color,
     disabled,
@@ -46,6 +47,7 @@ const Tab = props => {
 
   const className = clsx(
     "root",
+    orientation === "horizontal" && breakpoint !== "none" ? "breakpoint" : null,
     active || displayActive ? `${color}-active` : null,
     active || displayActive ? `${orientation}-active` : null,
     color,
@@ -147,6 +149,27 @@ const Tab = props => {
           flex-shrink: 1;
           max-width: none;
         }
+
+        @media (max-width: ${theme.breakpoints[breakpoint]}px) {
+          .breakpoint {
+            margin: 0 ${theme.spacing(1)}px;
+            padding: ${theme.spacing(2)}px 0;
+            position: relative;
+          }
+
+          .breakpoint:not(:last-child)::after {
+            border-right: 1px solid ${theme.palette.divider};
+            content: "";
+            height: ${theme.spacing(6)}px;
+            position: absolute;
+            right: ${theme.spacing(-1)}px;
+          }
+
+          .breakpoint > * {
+            font-size: ${theme.typography.body2.fontSize};
+            padding: ${theme.spacing(1)}px ${theme.spacing(3)}px;
+          }
+        }
       `}</style>
     </React.Fragment>
   );
@@ -154,6 +177,7 @@ const Tab = props => {
 
 Tab.defaultProps = {
   active: false,
+  breakpoint: "sm",
   color: "secondary",
   disabled: false,
   fullWidth: false,
@@ -165,6 +189,11 @@ Tab.propTypes = {
    * If `true`, the tab indicator will be displayed.
    */
   active: PropTypes.bool,
+
+  /**
+   * The breakpoint to display the mobile tab styling. Use "none" for no styling.
+   */
+  breakpoint: PropTypes.oneOf(["sm", "md", "lg", "xl", "none"]),
 
   /**
    * An array of custom CSS classes to apply.

--- a/packages/riipen-ui/src/components/Tabs.jsx
+++ b/packages/riipen-ui/src/components/Tabs.jsx
@@ -9,6 +9,11 @@ class Tabs extends React.Component {
 
   static propTypes = {
     /**
+     * The breakpoint to display the mobile tab styling. Use "none" for no styling.
+     */
+    breakpoint: PropTypes.oneOf(["sm", "md", "lg", "xl", "none"]),
+
+    /**
      * The content of the component.
      */
     children: PropTypes.node,
@@ -58,6 +63,7 @@ class Tabs extends React.Component {
   };
 
   static defaultProps = {
+    breakpoint: "sm",
     color: "secondary",
     component: "div",
     orientation: "horizontal",
@@ -74,6 +80,7 @@ class Tabs extends React.Component {
 
   render() {
     const {
+      breakpoint,
       children,
       classes,
       color,
@@ -92,6 +99,7 @@ class Tabs extends React.Component {
 
       return React.cloneElement(child, {
         active,
+        breakpoint,
         color,
         fullWidth: variant === "fullWidth",
         onClick: this.handleChange,


### PR DESCRIPTION
## Description
Update tabs styling to have dividers and smaller font between them at a designated breakpoint.
-add breakpoint prop
-add examples

## Screenshots
![Screenshot_2020-09-30 Tabs Riipen UI(1)](https://user-images.githubusercontent.com/10818279/94729550-ab1e8500-0316-11eb-97df-d66fc9ad114a.png)

## Where to Start
packages/riipen-ui/src/components/Tabs.jsx 