### PR TITLE
Add ContainerHeader component

### DIFF
--- a/packages/riipen-ui-docs/pages/components-api/container-header.jsx
+++ b/packages/riipen-ui-docs/pages/components-api/container-header.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+import MarkdownPage from "src/modules/components/MarkdownPage";
+
+const req = require.context(
+  "src/pages/components-api",
+  false,
+  /container-header.md$/
+);
+
+export default function Page() {
+  return (
+    <MarkdownPage
+      path="pages/components-api/container-header"
+      req={req}
+      title="Container Header API"
+    />
+  );
+}

--- a/packages/riipen-ui-docs/src/pages/components-api/container-header.md
+++ b/packages/riipen-ui-docs/src/pages/components-api/container-header.md
@@ -1,0 +1,28 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
+# ContainerHeader API
+
+<p class="description">The API documentation of the ContainerHeader React component.</p>
+
+## Import
+
+```js
+import ContainerHeader from 'riipen-ui/ContainerHeader';
+
+// or
+
+import { ContainerHeader } from 'riipen-ui';
+```
+
+You can learn more about the difference by [reading this guide](/guides/bundle-size).
+
+## Props
+
+| Name | Type | Default | Description |
+|:-----|:-----|:--------|:------------|
+| <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The content to display. |
+| <span class="prop-name">classes</span> | <span class="prop-type">array</span> |  | List of additional classes to apply to this component. |
+| <span class="prop-name">color</span> | <span class="prop-type">"default"<br>&#124;&nbsp;"negative"<br>&#124;&nbsp;"positive"<br>&#124;&nbsp;"primary"<br>&#124;&nbsp;"secondary"<br>&#124;&nbsp;"tertiary"<br>&#124;&nbsp;"warning"</span> |  | The color of the header. |
+
+
+Any other props supplied will be provided to the root element.

--- a/packages/riipen-ui-docs/src/pages/components/container/Border.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/container/Border.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+import Container from "riipen-ui/components/Container";
+
+export default function Border() {
+  const style = {
+    padding: "10px",
+    marginBottom: "10px",
+    textAlign: "center"
+  };
+
+  return (
+    <div>
+      <Container maxWidth="md" border>
+        <div style={style}>border</div>
+      </Container>
+    </div>
+  );
+}

--- a/packages/riipen-ui-docs/src/pages/components/container/Colors.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/container/Colors.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+import Container from "riipen-ui/components/Container";
+
+export default function Colors() {
+  const style = {
+    padding: "10px",
+    marginBottom: "10px",
+    textAlign: "center"
+  };
+
+  return (
+    <div>
+      <Container border color="white" maxWidth="md">
+        <div style={style}>white</div>
+      </Container>
+      <Container border color="default" maxWidth="md">
+        <div style={style}>default</div>
+      </Container>
+    </div>
+  );
+}

--- a/packages/riipen-ui-docs/src/pages/components/container/Headers.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/container/Headers.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import Container from "riipen-ui/components/Container";
+import ContainerHeader from "riipen-ui/components/ContainerHeader";
 
 export default function Headers() {
   const style = {
@@ -15,43 +16,51 @@ export default function Headers() {
     <div>
       <Container
         maxWidth="md"
-        headerProps={{ children: "primary", color: "primary" }}
+        header={<ContainerHeader color="primary">{"primary"}</ContainerHeader>}
       >
         <div style={style}>md</div>
       </Container>
       <Container
         maxWidth="md"
-        headerProps={{ children: "secondary", color: "secondary" }}
+        header={
+          <ContainerHeader color="secondary">{"secondary"}</ContainerHeader>
+        }
       >
         <div style={style}>md</div>
       </Container>
       <Container
         maxWidth="md"
-        headerProps={{ children: "tertiary", color: "tertiary" }}
+        header={
+          <ContainerHeader color="tertiary">{"tertiary"}</ContainerHeader>
+        }
       >
         <div style={style}>md</div>
       </Container>
       <Container
         maxWidth="md"
-        headerProps={{ children: "positive", color: "positive" }}
+        header={
+          <ContainerHeader color="positive">{"positive"}</ContainerHeader>
+        }
       >
         <div style={style}>md</div>
       </Container>
       <Container
         maxWidth="md"
-        headerProps={{ children: "negative", color: "negative" }}
+        header={
+          <ContainerHeader color="negative">{"negative"}</ContainerHeader>
+        }
       >
         <div style={style}>md</div>
       </Container>
       <Container
         maxWidth="md"
-        headerProps={{ children: "warning", color: "warning" }}
+        header={<ContainerHeader color="warning">{"warning"}</ContainerHeader>}
       >
         <div style={style}>md</div>
       </Container>
       <Container
         maxWidth="md"
-        headerProps={{ children: "default", color: "default" }}
+        header={<ContainerHeader color="default">{"default"}</ContainerHeader>}
       >
         <div style={style}>md</div>
       </Container>

--- a/packages/riipen-ui-docs/src/pages/components/container/Headers.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/container/Headers.jsx
@@ -1,0 +1,60 @@
+import React from "react";
+
+import Container from "riipen-ui/components/Container";
+
+export default function Headers() {
+  const style = {
+    backgroundColor: "#fff",
+    boxShadow: "0 1px 3px 0 rgba(0, 0, 0, 0.23)",
+    padding: "10px",
+    marginBottom: "10px",
+    textAlign: "center"
+  };
+
+  return (
+    <div>
+      <Container
+        maxWidth="md"
+        headerProps={{ children: "primary", color: "primary" }}
+      >
+        <div style={style}>md</div>
+      </Container>
+      <Container
+        maxWidth="md"
+        headerProps={{ children: "secondary", color: "secondary" }}
+      >
+        <div style={style}>md</div>
+      </Container>
+      <Container
+        maxWidth="md"
+        headerProps={{ children: "tertiary", color: "tertiary" }}
+      >
+        <div style={style}>md</div>
+      </Container>
+      <Container
+        maxWidth="md"
+        headerProps={{ children: "positive", color: "positive" }}
+      >
+        <div style={style}>md</div>
+      </Container>
+      <Container
+        maxWidth="md"
+        headerProps={{ children: "negative", color: "negative" }}
+      >
+        <div style={style}>md</div>
+      </Container>
+      <Container
+        maxWidth="md"
+        headerProps={{ children: "warning", color: "warning" }}
+      >
+        <div style={style}>md</div>
+      </Container>
+      <Container
+        maxWidth="md"
+        headerProps={{ children: "default", color: "default" }}
+      >
+        <div style={style}>md</div>
+      </Container>
+    </div>
+  );
+}

--- a/packages/riipen-ui-docs/src/pages/components/container/container.md
+++ b/packages/riipen-ui-docs/src/pages/components/container/container.md
@@ -12,7 +12,7 @@ A container width is bounded by the `maxWidth` property value.
 
 ## Headers
 
-A container can also have a header by specifying the `headerProps'.
+A container can also have a header by specifying the `headerProps`.
 
 {{"demo": "pages/components/container/Headers.js"}}
 

--- a/packages/riipen-ui-docs/src/pages/components/container/container.md
+++ b/packages/riipen-ui-docs/src/pages/components/container/container.md
@@ -9,3 +9,9 @@ While containers can be nested, most layouts do not require a nested container.
 A container width is bounded by the `maxWidth` property value.
 
 {{"demo": "pages/components/container/Widths.js"}}
+
+## Headers
+
+A container can also have a header by specifying the `headerProps'.
+
+{{"demo": "pages/components/container/Headers.js"}}

--- a/packages/riipen-ui-docs/src/pages/components/container/container.md
+++ b/packages/riipen-ui-docs/src/pages/components/container/container.md
@@ -15,3 +15,15 @@ A container width is bounded by the `maxWidth` property value.
 A container can also have a header by specifying the `headerProps'.
 
 {{"demo": "pages/components/container/Headers.js"}}
+
+## Border
+
+The `border` prop gives the container a border.
+
+{{"demo": "pages/components/container/Border.js"}}
+
+## Color
+
+You can use the `color` prop to change the container's color.
+
+{{"demo": "pages/components/container/Colors.js"}}

--- a/packages/riipen-ui-docs/src/pages/components/container/container.md
+++ b/packages/riipen-ui-docs/src/pages/components/container/container.md
@@ -12,7 +12,7 @@ A container width is bounded by the `maxWidth` property value.
 
 ## Headers
 
-A container can also have a header by specifying the `headerProps`.
+A container can also have a `header`.
 
 {{"demo": "pages/components/container/Headers.js"}}
 

--- a/packages/riipen-ui/src/components/Container.jsx
+++ b/packages/riipen-ui/src/components/Container.jsx
@@ -77,7 +77,7 @@ Container.propTypes = {
   /**
    * The color of the container.
    */
-  color: PropTypes.oneOf("default", "white"),
+  color: PropTypes.oneOf(["default", "white"]),
 
   /**
    * The props to pass to the ContainerHeader.

--- a/packages/riipen-ui/src/components/Container.jsx
+++ b/packages/riipen-ui/src/components/Container.jsx
@@ -5,16 +5,7 @@ import React from "react";
 import ThemeContext from "../styles/ThemeContext";
 import withClasses from "../utils/withClasses";
 
-import ContainerHeader from "./ContainerHeader";
-
-const Container = ({
-  border,
-  classes,
-  children,
-  color,
-  headerProps,
-  maxWidth
-}) => {
+const Container = ({ border, classes, children, color, header, maxWidth }) => {
   const theme = React.useContext(ThemeContext);
 
   const className = clsx("root", classes);
@@ -22,7 +13,7 @@ const Container = ({
   return (
     <React.Fragment>
       <div className={className}>
-        {headerProps && <ContainerHeader {...headerProps} />}
+        {header}
         <div className={clsx(border && "border", color)}>{children}</div>
       </div>
       <style jsx>{`
@@ -80,9 +71,9 @@ Container.propTypes = {
   color: PropTypes.oneOf(["default", "white"]),
 
   /**
-   * The props to pass to the ContainerHeader.
+   * The header component.
    */
-  headerProps: PropTypes.object,
+  header: PropTypes.node,
 
   /**
    * Determine the max-width of the container.

--- a/packages/riipen-ui/src/components/Container.jsx
+++ b/packages/riipen-ui/src/components/Container.jsx
@@ -12,6 +12,11 @@ class Container extends React.Component {
 
   static propTypes = {
     /**
+     * Whether to have a border around the container.
+     */
+    border: PropTypes.bool,
+
+    /**
      * The content inside the container.
      */
     children: PropTypes.any,
@@ -20,6 +25,11 @@ class Container extends React.Component {
      * List of additional classes to apply to this component.
      */
     classes: PropTypes.array,
+
+    /**
+     * The color of the container.
+     */
+    color: PropTypes.oneOf("default", "white"),
 
     /**
      * The props to pass to the ContainerHeader.
@@ -34,27 +44,36 @@ class Container extends React.Component {
   };
 
   static defaultProps = {
+    border: false,
     classes: [],
+    color: "default",
     maxWidth: "lg"
   };
 
   static contextType = ThemeContext;
 
   render() {
-    const { classes, children, headerProps, maxWidth } = this.props;
+    const {
+      border,
+      classes,
+      children,
+      color,
+      headerProps,
+      maxWidth
+    } = this.props;
 
     const theme = this.context;
 
-    const className = clsx(classes);
+    const className = clsx("root", classes);
 
     return (
       <React.Fragment>
         <div className={className}>
           {headerProps && <ContainerHeader {...headerProps} />}
-          {children}
+          <div className={clsx(border && "border", color)}>{children}</div>
         </div>
         <style jsx>{`
-          div {
+          .root {
             box-sizing: border-box;
             margin: 0 auto;
             max-width: ${maxWidth
@@ -64,14 +83,22 @@ class Container extends React.Component {
             position: relative;
           }
 
+          .border {
+            box-shadow: ${theme.shadows[1]};
+          }
+
+          .white {
+            background-color: ${theme.palette.common.white};
+          }
+
           @media (max-width: ${theme.breakpoints.lg}px) {
-            div {
+            .root {
               padding: 0 ${theme.spacing(5)}px;
             }
           }
 
           @media (max-width: ${theme.breakpoints.md}px) {
-            div {
+            .root {
               padding: 0 ${theme.spacing(3)}px;
             }
           }

--- a/packages/riipen-ui/src/components/Container.jsx
+++ b/packages/riipen-ui/src/components/Container.jsx
@@ -5,6 +5,8 @@ import React from "react";
 import ThemeContext from "../styles/ThemeContext";
 import withClasses from "../utils/withClasses";
 
+import ContainerHeader from "./ContainerHeader";
+
 class Container extends React.Component {
   static displayName = "Container";
 
@@ -18,6 +20,11 @@ class Container extends React.Component {
      * List of additional classes to apply to this component.
      */
     classes: PropTypes.array,
+
+    /**
+     * The props to pass to the ContainerHeader.
+     */
+    headerProps: PropTypes.object,
 
     /**
      * Determine the max-width of the container.
@@ -34,7 +41,7 @@ class Container extends React.Component {
   static contextType = ThemeContext;
 
   render() {
-    const { classes, children, maxWidth } = this.props;
+    const { classes, children, headerProps, maxWidth } = this.props;
 
     const theme = this.context;
 
@@ -42,7 +49,10 @@ class Container extends React.Component {
 
     return (
       <React.Fragment>
-        <div className={className}>{children}</div>
+        <div className={className}>
+          {headerProps && <ContainerHeader {...headerProps} />}
+          {children}
+        </div>
         <style jsx>{`
           div {
             box-sizing: border-box;

--- a/packages/riipen-ui/src/components/Container.jsx
+++ b/packages/riipen-ui/src/components/Container.jsx
@@ -7,105 +7,97 @@ import withClasses from "../utils/withClasses";
 
 import ContainerHeader from "./ContainerHeader";
 
-class Container extends React.Component {
-  static displayName = "Container";
+const Container = ({
+  border,
+  classes,
+  children,
+  color,
+  headerProps,
+  maxWidth
+}) => {
+  const theme = React.useContext(ThemeContext);
 
-  static propTypes = {
-    /**
-     * Whether to have a border around the container.
-     */
-    border: PropTypes.bool,
+  const className = clsx("root", classes);
 
-    /**
-     * The content inside the container.
-     */
-    children: PropTypes.any,
+  return (
+    <React.Fragment>
+      <div className={className}>
+        {headerProps && <ContainerHeader {...headerProps} />}
+        <div className={clsx(border && "border", color)}>{children}</div>
+      </div>
+      <style jsx>{`
+        .root {
+          box-sizing: border-box;
+          margin: 0 auto;
+          max-width: ${maxWidth ? `${theme.breakpoints[maxWidth]}px` : "100%"};
+          padding: 0 ${theme.spacing(6)}px;
+          position: relative;
+        }
 
-    /**
-     * List of additional classes to apply to this component.
-     */
-    classes: PropTypes.array,
+        .border {
+          box-shadow: ${theme.shadows[1]};
+        }
 
-    /**
-     * The color of the container.
-     */
-    color: PropTypes.oneOf("default", "white"),
+        .white {
+          background-color: ${theme.palette.common.white};
+        }
 
-    /**
-     * The props to pass to the ContainerHeader.
-     */
-    headerProps: PropTypes.object,
-
-    /**
-     * Determine the max-width of the container.
-     * The container width grows with the size of the screen.
-     */
-    maxWidth: PropTypes.oneOf(["sm", "md", "lg", "xl", false])
-  };
-
-  static defaultProps = {
-    border: false,
-    classes: [],
-    color: "default",
-    maxWidth: "lg"
-  };
-
-  static contextType = ThemeContext;
-
-  render() {
-    const {
-      border,
-      classes,
-      children,
-      color,
-      headerProps,
-      maxWidth
-    } = this.props;
-
-    const theme = this.context;
-
-    const className = clsx("root", classes);
-
-    return (
-      <React.Fragment>
-        <div className={className}>
-          {headerProps && <ContainerHeader {...headerProps} />}
-          <div className={clsx(border && "border", color)}>{children}</div>
-        </div>
-        <style jsx>{`
+        @media (max-width: ${theme.breakpoints.lg}px) {
           .root {
-            box-sizing: border-box;
-            margin: 0 auto;
-            max-width: ${maxWidth
-              ? `${theme.breakpoints[maxWidth]}px`
-              : "100%"};
-            padding: 0 ${theme.spacing(6)}px;
-            position: relative;
+            padding: 0 ${theme.spacing(5)}px;
           }
+        }
 
-          .border {
-            box-shadow: ${theme.shadows[1]};
+        @media (max-width: ${theme.breakpoints.md}px) {
+          .root {
+            padding: 0 ${theme.spacing(3)}px;
           }
+        }
+      `}</style>
+    </React.Fragment>
+  );
+};
 
-          .white {
-            background-color: ${theme.palette.common.white};
-          }
+Container.propTypes = {
+  /**
+   * Whether to have a border around the container.
+   */
+  border: PropTypes.bool,
 
-          @media (max-width: ${theme.breakpoints.lg}px) {
-            .root {
-              padding: 0 ${theme.spacing(5)}px;
-            }
-          }
+  /**
+   * The content inside the container.
+   */
+  children: PropTypes.any,
 
-          @media (max-width: ${theme.breakpoints.md}px) {
-            .root {
-              padding: 0 ${theme.spacing(3)}px;
-            }
-          }
-        `}</style>
-      </React.Fragment>
-    );
-  }
-}
+  /**
+   * List of additional classes to apply to this component.
+   */
+  classes: PropTypes.array,
+
+  /**
+   * The color of the container.
+   */
+  color: PropTypes.oneOf("default", "white"),
+
+  /**
+   * The props to pass to the ContainerHeader.
+   */
+  headerProps: PropTypes.object,
+
+  /**
+   * Determine the max-width of the container.
+   * The container width grows with the size of the screen.
+   */
+  maxWidth: PropTypes.oneOf(["sm", "md", "lg", "xl", false])
+};
+
+Container.defaultProps = {
+  border: false,
+  classes: [],
+  color: "default",
+  maxWidth: "lg"
+};
+
+Container.displayName = "Container";
 
 export default withClasses(Container);

--- a/packages/riipen-ui/src/components/ContainerHeader.jsx
+++ b/packages/riipen-ui/src/components/ContainerHeader.jsx
@@ -1,0 +1,94 @@
+import clsx from "clsx";
+import PropTypes from "prop-types";
+import React from "react";
+
+import { withThemeContext } from "../utils";
+
+const ContainerHeader = ({ children, classes, color, theme }) => {
+  return (
+    <React.Fragment>
+      <div className={clsx("root", color, classes)}>{children}</div>
+      <style jsx>{`
+        .root {
+          background-color: ${theme.palette.grey[300]};
+          border-radius: ${theme.shape.borderRadius.md}
+            ${theme.shape.borderRadius.md} 0 0;
+          box-shadow: ${theme.shadows[1]};
+          color: ${theme.palette.common.white};
+          display: flex;
+          font-family: ${theme.typography.body1.fontFamily};
+          font-size: ${theme.typography.body1.fontSize};
+          font-weight: ${theme.typography.body1.fontWeight};
+          letter-spacing: ${theme.typography.body1.letterSpacing};
+          line-height: ${theme.typography.body1.lineHeight};
+          justify-content: space-between;
+          overflow: hidden;
+          padding: ${theme.spacing(2)}px;
+        }
+
+        .primary {
+          background-color: ${theme.palette.primary.main};
+        }
+
+        .secondary {
+          background-color: ${theme.palette.secondary.main};
+        }
+
+        .tertiary {
+          background-color: ${theme.palette.tertiary.main};
+        }
+
+        .negative {
+          background-color: ${theme.palette.negative.main};
+        }
+
+        .warning {
+          background-color: ${theme.palette.warning.main};
+        }
+
+        .positive {
+          background-color: ${theme.palette.positive.main};
+        }
+      `}</style>
+    </React.Fragment>
+  );
+};
+
+ContainerHeader.propTypes = {
+  /**
+   * The content to display.
+   */
+  children: PropTypes.node,
+
+  /**
+   * List of additional classes to apply to this component.
+   */
+  classes: PropTypes.array,
+
+  /**
+   * The color of the header.
+   */
+  color: PropTypes.oneOf([
+    "default",
+    "negative",
+    "positive",
+    "primary",
+    "secondary",
+    "tertiary",
+    "warning"
+  ]),
+
+  /**
+   * @ignore
+   * The theme context object
+   */
+  theme: PropTypes.object
+};
+
+ContainerHeader.deafultProps = {
+  color: "default"
+};
+
+ContainerHeader.displayName = "ContainerHeader";
+
+export default withThemeContext(ContainerHeader);


### PR DESCRIPTION
## Description
Add ContainerHeader component that gives containers a coloured header.
Update Container component to have colour, border, and header options.
Convert Container to functional component.

## Screenshots
![Screenshot_2020-10-16 Container Riipen UI(1)](https://user-images.githubusercontent.com/10818279/96322994-1d0df400-0fd0-11eb-8ab2-e9145e37b6b4.png)
![Screenshot_2020-10-16 Container Riipen UI(2)](https://user-images.githubusercontent.com/10818279/96322995-1da68a80-0fd0-11eb-9d57-dfbaf387e189.png)
![Screenshot_2020-10-16 Container Riipen UI(3)](https://user-images.githubusercontent.com/10818279/96323004-3020c400-0fd0-11eb-8205-3835b15043a7.png)

## Where to Start
components/ContainerHeader
components/Container - last commit converts to functional component.
