### PR TITLE
Fixed error when menu item used improperly

### DIFF
--- a/packages/riipen-ui/src/components/MenuList.jsx
+++ b/packages/riipen-ui/src/components/MenuList.jsx
@@ -138,7 +138,11 @@ class MenuList extends React.Component {
     }
 
     const nextItem = listItems[nextIndex];
-    if (!nextItem.props.disabled) {
+    if (!nextItem) {
+      return;
+    }
+
+    if (nextItem.props && !nextItem.props.disabled) {
       this.handleSelectChange(nextIndex, event);
       return;
     }


### PR DESCRIPTION
## Description
Error on dashboard when user is traversing the menu using keyboard inputs
[rollbar #1812](https://rollbar.com/riipen/platform-web/items/1812/)

## Notes
Was unable to duplicate the error so I just added safety checks to make sure the component doesnt crash

## Where to Start
packages/riipen-ui/src/components/MenuList.jsx