### PR TITLE
[PLT-5814] Add VerticalProgressBar to the UI-Kit

### DIFF
--- a/packages/riipen-ui-docs/pages/components-api/vertical-progress-bar.jsx
+++ b/packages/riipen-ui-docs/pages/components-api/vertical-progress-bar.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+import MarkdownPage from "src/modules/components/MarkdownPage";
+
+const req = require.context(
+  "src/pages/components-api",
+  false,
+  /vertical-progress-bar.md$/
+);
+
+export default function Page() {
+  return (
+    <MarkdownPage
+      path="pages/components-api/vertical-progress-bar"
+      req={req}
+      title="Vertical Progress Bar API"
+    />
+  );
+}

--- a/packages/riipen-ui-docs/pages/components/vertical-progress-bar.jsx
+++ b/packages/riipen-ui-docs/pages/components/vertical-progress-bar.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+import MarkdownPage from "src/modules/components/MarkdownPage";
+
+const req = require.context(
+  "src/pages/components/vertical-progress-bar",
+  false,
+  /\.(md|js|jsx)$/
+);
+
+const reqSource = require.context(
+  "!raw-loader!../../src/pages/components/vertical-progress-bar",
+  false,
+  /\.(js|jsx)$/
+);
+
+export default function Page() {
+  return (
+    <MarkdownPage
+      path="pages/components/vertical-progress-bar"
+      req={req}
+      reqSource={reqSource}
+      title="Vertical Progress Bar"
+    />
+  );
+}

--- a/packages/riipen-ui-docs/src/pages.js
+++ b/packages/riipen-ui-docs/src/pages.js
@@ -114,6 +114,10 @@ const pages = [
         pathname: "/components/progress-bar"
       },
       {
+        name: "Vertical Progress Bar",
+        pathname: "/components/vertical-progress-bar"
+      },
+      {
         name: "Radio",
         pathname: "/components/radio"
       },
@@ -242,6 +246,10 @@ const pages = [
       {
         name: "Progress Bar",
         pathname: "/components-api/progress-bar"
+      },
+      {
+        name: "Vertical Progress Bar",
+        pathname: "/components-api/vertical-progress-bar"
       },
       {
         name: "Rich Text Editor",

--- a/packages/riipen-ui-docs/src/pages/components/vertical-progress-bar/Color.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/vertical-progress-bar/Color.jsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+import VerticalProgressBar from "riipen-ui/components/VerticalProgressBar";
+
+export default function Color() {
+  return (
+    <VerticalProgressBar
+      progresses={[
+        { color: "positive" },
+        { color: "warning" },
+        { color: "positive" },
+        { color: "default" }
+      ]}
+    />
+  );
+}

--- a/packages/riipen-ui-docs/src/pages/components/vertical-progress-bar/Content.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/vertical-progress-bar/Content.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+
+import VerticalProgressBar from "riipen-ui/components/VerticalProgressBar";
+
+import { faChevronRight } from "@fortawesome/free-solid-svg-icons";
+
+export default function Content() {
+  return (
+    <VerticalProgressBar
+      progresses={[
+        {
+          icon: faChevronRight,
+          color: "positive",
+          children: "content 1"
+        },
+        {
+          icon: faChevronRight,
+          color: "positive",
+          children: "content 2"
+        },
+        {
+          icon: faChevronRight,
+          color: "positive",
+          children: "content 3"
+        },
+        {
+          icon: faChevronRight,
+          color: "positive",
+          children: "content 4"
+        }
+      ]}
+    />
+  );
+}

--- a/packages/riipen-ui-docs/src/pages/components/vertical-progress-bar/Icon.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/vertical-progress-bar/Icon.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+import VerticalProgressBar from "riipen-ui/components/VerticalProgressBar";
+
+import { faChevronRight, faAtom } from "@fortawesome/free-solid-svg-icons";
+
+export default function Icon() {
+  return (
+    <VerticalProgressBar
+      progresses={[
+        { icon: faAtom, color: "positive" },
+        { icon: faChevronRight, color: "positive" },
+        { icon: faAtom, color: "positive" },
+        { icon: faChevronRight, color: "positive" }
+      ]}
+    />
+  );
+}

--- a/packages/riipen-ui-docs/src/pages/components/vertical-progress-bar/vertical-progress-bar.md
+++ b/packages/riipen-ui-docs/src/pages/components/vertical-progress-bar/vertical-progress-bar.md
@@ -1,0 +1,25 @@
+# Vertical Progress Bar
+
+<p class="description">A vertical progress bar allows users to view the completion stages of something.</p>
+
+Vertical progress bars communicate progress or completion amount of a given task.
+
+## Colors
+
+Portions of the vertical progress bar can be rendered with different colors to indicate success or a warning at a certain stage.
+
+{{"demo": "pages/components/vertical-progress-bar/Color.js"}}
+
+And can have either a light or dark unfilled color.
+
+## Icons
+
+The bubbles in the progress bar can house any icon or none at all.
+
+{{"demo": "pages/components/vertical-progress-bar/Icon.js"}}
+
+## Content
+
+Content alongside the vertical progress bar can be included or excluded as children.
+
+{{"demo": "pages/components/vertical-progress-bar/Content.js"}}

--- a/packages/riipen-ui/src/components/VerticalProgressBar.jsx
+++ b/packages/riipen-ui/src/components/VerticalProgressBar.jsx
@@ -1,0 +1,62 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import withClasses from "../utils/withClasses";
+
+import Grid from "./Grid";
+import GridItem from "./GridItem";
+import VerticalProgressBarItem from "./VerticalProgressBarItem";
+
+const VerticalProgressBar = ({ progresses }) => {
+  const renderProgress = () => {
+    return progresses.map((progress, index) => (
+      <GridItem key={`progress-${index}`}>
+        <VerticalProgressBarItem
+          progress={{ ...progress, noBar: index >= progresses.length - 1 }}
+        />
+      </GridItem>
+    ));
+  };
+  return (
+    <div>
+      <Grid spacing={0}>{renderProgress()}</Grid>
+    </div>
+  );
+};
+
+VerticalProgressBar.propTypes = {
+  // external
+
+  /**
+   * The progresses to display.
+   */
+  progresses: PropTypes.arrayOf(
+    PropTypes.shape({
+      /**
+       * The progress icon.
+       */
+      icon: PropTypes.object,
+
+      /**
+       * The content to render inside.
+       */
+      children: PropTypes.node,
+
+      /**
+       * The colour of the progress icon.
+       */
+      color: PropTypes.string,
+
+      /**
+       * Whether to not have bar.
+       */
+      noBar: PropTypes.bool
+    })
+  )
+};
+
+VerticalProgressBar.defaultProps = {
+  progresses: []
+};
+
+export default withClasses(VerticalProgressBar);

--- a/packages/riipen-ui/src/components/VerticalProgressBar.jsx
+++ b/packages/riipen-ui/src/components/VerticalProgressBar.jsx
@@ -17,11 +17,8 @@ const VerticalProgressBar = ({ progresses }) => {
       </GridItem>
     ));
   };
-  return (
-    <div>
-      <Grid spacing={0}>{renderProgress()}</Grid>
-    </div>
-  );
+
+  return <Grid spacing={0}>{renderProgress()}</Grid>;
 };
 
 VerticalProgressBar.propTypes = {

--- a/packages/riipen-ui/src/components/VerticalProgressBarItem.jsx
+++ b/packages/riipen-ui/src/components/VerticalProgressBarItem.jsx
@@ -1,0 +1,143 @@
+import clsx from "clsx";
+import React from "react";
+import PropTypes from "prop-types";
+import css from "styled-jsx/css";
+
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+import ThemeContext from "../styles/ThemeContext";
+import withClasses from "../utils/withClasses";
+
+import Grid from "./Grid";
+import GridItem from "./GridItem";
+
+const VerticalProgressBarItem = ({ progress }) => {
+  const theme = React.useContext(ThemeContext);
+
+  const getLinkedStyles = () => {
+    return css.resolve`
+      .icon {
+        color: ${theme.palette.common.white};
+        z-index: ${theme.zIndex.low};
+      }
+
+      .wrapper {
+        margin-top: ${theme.spacing(-6)}px;
+      }
+    `;
+  };
+
+  const linkedStyles = getLinkedStyles();
+
+  const iconClasses = [
+    "iconWrapper",
+    progress.color && `${progress.color}`
+  ].filter(Boolean);
+
+  const className = clsx(
+    "progress",
+    progress.color && !progress.noBar && `progress-${progress.color}`,
+    progress.noBar && "progress-none"
+  );
+
+  return (
+    <React.Fragment>
+      <div className={className}>
+        <Grid classes={[linkedStyles.className, "wrapper"]} spacing={0}>
+          <GridItem lg={2}>
+            <div className={clsx(iconClasses)}>
+              {!!progress.icon && (
+                <FontAwesomeIcon
+                  className={clsx(linkedStyles.className, "icon")}
+                  size="sm"
+                  icon={progress.icon}
+                />
+              )}
+            </div>
+          </GridItem>
+          <GridItem lg={10}>{progress.children}</GridItem>
+        </Grid>
+      </div>
+      <style jsx>{`
+        .default {
+          background-color: ${theme.palette.grey[300]};
+        }
+
+        .positive {
+          background-color: ${theme.palette.positive.main};
+        }
+
+        .warning {
+          background-color: ${theme.palette.warning.main};
+        }
+
+        .progress {
+          border-left: 8px solid var(--border-color);
+          margin-left: ${theme.spacing(3)}px;
+          padding: ${theme.spacing(4)}px 0;
+        }
+
+        /* Progress bar colors. */
+        .progress-default {
+          --border-color: ${theme.palette.grey[300]};
+        }
+
+        .progress-none {
+          --border-color: transparent;
+        }
+
+        .progress-positive {
+          --border-color: ${theme.palette.positive.main};
+        }
+
+        .progress-warning {
+          --border-color: ${theme.palette.warning.main};
+        }
+
+        .iconWrapper {
+          align-items: center;
+          border-radius: 50%;
+          display: flex;
+          height: 24px;
+          justify-content: center;
+          margin: ${theme.spacing(2)}px 0 ${theme.spacing(7)}px
+            ${theme.spacing(-4.65)}px;
+          padding: ${theme.spacing(1.5)}px;
+          width: 24px;
+        }
+      `}</style>
+      {linkedStyles.styles}
+    </React.Fragment>
+  );
+};
+
+VerticalProgressBarItem.propTypes = {
+  // external
+
+  /**
+   * The progress to render.
+   */
+  progress: PropTypes.shape({
+    /**
+     * The content to render inside.
+     */
+    children: PropTypes.node,
+
+    /**
+     * The colour of the progress icon.
+     */
+    color: PropTypes.oneOf(["positive", "warning", "default"]),
+
+    /**
+     * The progress icon.
+     */
+    icon: PropTypes.object,
+
+    /**
+     * Whether to not have bar.
+     */
+    noBar: PropTypes.bool
+  }).isRequired
+};
+
+export default withClasses(VerticalProgressBarItem);

--- a/packages/riipen-ui/src/components/VerticalProgressBarItem.jsx
+++ b/packages/riipen-ui/src/components/VerticalProgressBarItem.jsx
@@ -100,9 +100,8 @@ const VerticalProgressBarItem = ({ progress }) => {
           display: flex;
           height: 24px;
           justify-content: center;
-          margin: ${theme.spacing(2)}px 0 ${theme.spacing(7)}px
-            ${theme.spacing(-4.65)}px;
-          padding: ${theme.spacing(1.5)}px;
+          margin: ${theme.spacing(2)}px 0 ${theme.spacing(7)}px -23px;
+          padding: 7px;
           width: 24px;
         }
       `}</style>


### PR DESCRIPTION
_[Jira Ticket: [PLT-5814]](https://riipen.atlassian.net/browse/PLT-5814)_

## Description
The `ProgressBarVertical` component implemented [here](https://github.com/riipen/platform-web/pull/2986) by @ksmort needed to be added to the UI-Kit.

## Notes
To be honest I floundered quite a bit troubleshooting the CSS and figuring out that some of it wasn't being picked up by the `Grid` component. I ended up using `linkedStyles` to make it happen once I got some assistance.

For the most part I tried to mirror other components and could use some context as to what this achieves:
```
export default withClasses(VerticalProgressBarItem);
```
I wrote pretty small commits in case I really need to change things in multiple places.

## Screenshots
![Screen Shot 2020-10-29 at 3 06 37 PM](https://user-images.githubusercontent.com/28407708/97637698-5dba3400-19f8-11eb-8958-b6e124b2980d.png)