### PR TITLE
Update editor styles to match new designs

### DIFF
--- a/packages/riipen-ui-docs/src/pages/components-api/editor.md
+++ b/packages/riipen-ui-docs/src/pages/components-api/editor.md
@@ -20,7 +20,8 @@ You can learn more about the difference by [reading this guide](/guides/bundle-s
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span class="prop-name">additionalControls</span> | <span class="prop-type">node</span> | <span class="prop-default">[]</span> | Additional controls to display. |
+| <span class="prop-name">autoFocus</span> | <span class="prop-type">bool</span> | <span class="prop-default">true</span> | Whether or not to move focus the Editor on first render. |
+| <span class="prop-name">actionControls</span> | <span class="prop-type">Array<node></span> | <span class="prop-default">[]</span> | action controls to display on the right side of the editor control bar. |
 | <span class="prop-name">ariaLabelledBy</span> | <span class="prop-type">string</span> |  | The id of the element to use as the aria-label for the Editor. |
 | <span class="prop-name">controlWhitelist</span> | <span class="prop-type">Array<string></span> |  | Optional array of whitelisted styles ex. ['code-block', 'BOLD', 'LINK'] |
 | <span class="prop-name">controlPosition</span> | <span class="prop-type">"top"<br>&#124;&nbsp;"bottom"</span> | <span class="prop-default">"top"</span> | Position of controls for the editor |
@@ -39,6 +40,7 @@ You can learn more about the difference by [reading this guide](/guides/bundle-s
 | <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |  | Function to execute when editor content changes, gets html value of editor |
 | <span class="prop-name">placeholder</span> | <span class="prop-type">node</span> |  | Optional placeholder. Shows when there is no text. |
 | <span class="prop-name">style</span> | <span class="prop-type">object</span> |  | Optional style applied to parent div of editor. Used to set a minimum height. |
+| <span class="prop-name">stylingControls</span> | <span class="prop-type">Array<node></span> | <span class="prop-default">[]</span> | Additional action controls to display on the left side of the editor control bar. |
 
 
 Any other props supplied will be provided to the root element.

--- a/packages/riipen-ui-docs/src/pages/components-api/editor.md
+++ b/packages/riipen-ui-docs/src/pages/components-api/editor.md
@@ -20,8 +20,8 @@ You can learn more about the difference by [reading this guide](/guides/bundle-s
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span class="prop-name">autoFocus</span> | <span class="prop-type">bool</span> | <span class="prop-default">true</span> | Whether or not to move focus the Editor on first render. |
-| <span class="prop-name">actionControls</span> | <span class="prop-type">Array<node></span> | <span class="prop-default">[]</span> | action controls to display on the right side of the editor control bar. |
+| <span class="prop-name">autoFocus</span> | <span class="prop-type">bool</span> |  | Whether or not to move focus the Editor on first render. |
+| <span class="prop-name">actionControls</span> | <span class="prop-type">Array<node></span> | <span class="prop-default">[]</span> | Action controls to display on the right side of the editor control bar. |
 | <span class="prop-name">ariaLabelledBy</span> | <span class="prop-type">string</span> |  | The id of the element to use as the aria-label for the Editor. |
 | <span class="prop-name">controlWhitelist</span> | <span class="prop-type">Array<string></span> |  | Optional array of whitelisted styles ex. ['code-block', 'BOLD', 'LINK'] |
 | <span class="prop-name">controlPosition</span> | <span class="prop-type">"top"<br>&#124;&nbsp;"bottom"</span> | <span class="prop-default">"top"</span> | Position of controls for the editor |

--- a/packages/riipen-ui/src/components/Editor.jsx
+++ b/packages/riipen-ui/src/components/Editor.jsx
@@ -398,7 +398,7 @@ class Editor extends React.Component {
     }
   };
 
-  forceFocus = () => focus(true);
+  forceFocus = () => this.focus(true);
 
   // Control button callback for toggling block type
   toggleBlockType = blockType => {

--- a/packages/riipen-ui/src/components/Editor.jsx
+++ b/packages/riipen-ui/src/components/Editor.jsx
@@ -96,9 +96,19 @@ class Editor extends React.Component {
 
   static propTypes = {
     /**
-     * Additional controls to display.
+     * Whether or not to move focus the Editor on first render.
      */
-    additionalControls: PropTypes.node,
+    autoFocus: PropTypes.bool,
+
+    /**
+     * action controls to display on the right side of the editor control bar.
+     */
+    actionControls: PropTypes.arrayOf(PropTypes.node),
+
+    /**
+     * Additional action controls to display on the left side of the editor control bar.
+     */
+    stylingControls: PropTypes.arrayOf(PropTypes.node),
 
     /**
      * The id of the element to use as the aria-label for the Editor.
@@ -149,7 +159,9 @@ class Editor extends React.Component {
   };
 
   static defaultProps = {
-    additionalControls: [],
+    autoFocus: true,
+    stylingControls: [],
+    actionControls: [],
     controlPosition: "top"
   };
 
@@ -186,11 +198,12 @@ class Editor extends React.Component {
 
   getLinkedStyles = () => {
     const theme = this.context;
+    const { controlPosition } = this.props;
 
     return css.resolve`
       .wrapper {
         background-color: ${theme.palette.common.white};
-        border: 1px solid ${theme.palette.grey[400]};
+        border: 1px solid #979797;
         border-radius: ${theme.shape.borderRadius.md};
         font-family: ${theme.typography.body1.fontFamily};
         font-size: ${theme.typography.body1.fontSize};
@@ -214,11 +227,15 @@ class Editor extends React.Component {
       .editor.top {
         border-bottom-left-radius: ${theme.shape.borderRadius.md};
         border-bottom-right-radius: ${theme.shape.borderRadius.md};
-        border-top: 1px solid ${theme.palette.grey[400]};
+        border-top: ${controlPosition === "bottom"
+          ? `1px solid ${theme.palette.grey[400]}`
+          : "none"};
       }
 
       .editor.bottom {
-        border-bottom: 1px solid ${theme.palette.grey[400]};
+        border-bottom: ${controlPosition === "top"
+          ? `1px solid ${theme.palette.grey[400]}`
+          : "none"};
         border-top-left-radius: ${theme.shape.borderRadius.md};
         border-top-right-radius: ${theme.shape.borderRadius.md};
       }
@@ -242,15 +259,18 @@ class Editor extends React.Component {
       }
 
       .controlContainer {
-        margin: 0 ${theme.spacing(2)}px;
+        background-color: ${theme.palette.grey[100]};
+        display: flex;
+        flex: 1 1 auto;
+        flex-direction: row;
+        justify-content: space-between;
+        padding-left: ${theme.spacing(2)}px;
+        border-bottom-left-radius: 4px;
+        border-bottom-right-radius: 4px;
       }
 
-      .controlContainer > div {
+      .stylingControls > div:not(:last-child) {
         border-right: 1px solid ${theme.palette.divider};
-      }
-
-      .controlContainer > div:last-child {
-        border-right: none;
       }
 
       @media (max-width: ${theme.breakpoints.sm}px) {
@@ -323,13 +343,16 @@ class Editor extends React.Component {
    * Note: Does not keep editing history so use  sparingly.
    */
   setHtml = async html => {
-    const { decorator } = this.props;
+    const { decorator, autoFocus } = this.props;
 
     const contentState = convertFromHTML(fromHtmlConfig)(html || "");
     const editorState = EditorState.createWithContent(contentState, decorator);
 
     await this.onChange(editorState);
-    this.focus();
+
+    if (autoFocus) {
+      this.focus();
+    }
   };
 
   getHtml = () => {
@@ -369,8 +392,11 @@ class Editor extends React.Component {
     return getDefaultKeyBinding(e);
   };
 
-  focus = () => {
-    if (this.editor && this.editor.current) this.editor.current.focus();
+  focus = forceFocus => {
+    const { autoFocus } = this.props;
+    if ((this.editor && this.editor.current && autoFocus) || forceFocus) {
+      this.editor.current.focus();
+    }
   };
 
   // Control button callback for toggling block type
@@ -542,7 +568,7 @@ class Editor extends React.Component {
   static contextType = ThemeContext;
 
   renderControls = () => {
-    const { additionalControls } = this.props;
+    const { stylingControls, actionControls } = this.props;
     const { editorState } = this.state;
 
     const linkedStyles = this.getLinkedStyles();
@@ -550,27 +576,35 @@ class Editor extends React.Component {
     return (
       <React.Fragment>
         <div className={clsx(linkedStyles.className, "controlContainer")}>
-          <EditorBlockStyleControls
-            classes={[linkedStyles.className, "controlRow"]}
-            editorState={editorState}
-            toggle={this.toggleBlockType}
-            whitelist={this.props.controlWhitelist}
-          />
-          <EditorInlineStyleControls
-            classes={[linkedStyles.className, "controlRow"]}
-            editorState={editorState}
-            toggle={this.toggleInlineStyle}
-            whitelist={this.props.controlWhitelist}
-          />
-          {additionalControls &&
-            additionalControls.map((control, index) => (
-              <div
-                key={`control-${index}`}
-                className={clsx([linkedStyles.className, "controlRow"])}
-              >
-                {control}
-              </div>
-            ))}
+          <div className={clsx(linkedStyles.className, "stylingControls")}>
+            <EditorBlockStyleControls
+              classes={[linkedStyles.className, "controlRow"]}
+              editorState={editorState}
+              toggle={this.toggleBlockType}
+              whitelist={this.props.controlWhitelist}
+            />
+            <EditorInlineStyleControls
+              classes={[linkedStyles.className, "controlRow"]}
+              editorState={editorState}
+              toggle={this.toggleInlineStyle}
+              whitelist={this.props.controlWhitelist}
+            />
+            {stylingControls &&
+              stylingControls.map((control, index) => (
+                <div
+                  key={`control-${index}`}
+                  className={clsx([linkedStyles.className, "controlRow"])}
+                >
+                  {control}
+                </div>
+              ))}
+          </div>
+          <div>
+            {actionControls &&
+              actionControls.map((control, index) => (
+                <div key={`control-${index}`}>{control}</div>
+              ))}
+          </div>
         </div>
       </React.Fragment>
     );
@@ -615,7 +649,7 @@ class Editor extends React.Component {
 
     return (
       <React.Fragment>
-        <div className={wrapperClasses} onClick={this.focus}>
+        <div className={wrapperClasses} onClick={() => this.focus(true)}>
           {controlPosition === "top" && this.renderControls()}
           <div className={editorClasses} style={style}>
             <DraftJsEditor

--- a/packages/riipen-ui/src/components/Editor.jsx
+++ b/packages/riipen-ui/src/components/Editor.jsx
@@ -106,11 +106,6 @@ class Editor extends React.Component {
     actionControls: PropTypes.arrayOf(PropTypes.node),
 
     /**
-     * Additional action controls to display on the left side of the editor control bar.
-     */
-    stylingControls: PropTypes.arrayOf(PropTypes.node),
-
-    /**
      * The id of the element to use as the aria-label for the Editor.
      */
     ariaLabelledBy: PropTypes.string,
@@ -155,14 +150,19 @@ class Editor extends React.Component {
      * Optional style applied to parent div of editor.
      * Used to set a minimum height.
      */
-    style: PropTypes.object
+    style: PropTypes.object,
+
+    /**
+     * Additional action controls to display on the left side of the editor control bar.
+     */
+    stylingControls: PropTypes.arrayOf(PropTypes.node)
   };
 
   static defaultProps = {
     autoFocus: true,
-    stylingControls: [],
     actionControls: [],
-    controlPosition: "top"
+    controlPosition: "top",
+    stylingControls: []
   };
 
   constructor(props) {

--- a/packages/riipen-ui/src/components/Editor.jsx
+++ b/packages/riipen-ui/src/components/Editor.jsx
@@ -101,7 +101,7 @@ class Editor extends React.Component {
     autoFocus: PropTypes.bool,
 
     /**
-     * action controls to display on the right side of the editor control bar.
+     * Action controls to display on the right side of the editor control bar.
      */
     actionControls: PropTypes.arrayOf(PropTypes.node),
 
@@ -159,7 +159,6 @@ class Editor extends React.Component {
   };
 
   static defaultProps = {
-    autoFocus: true,
     actionControls: [],
     controlPosition: "top",
     stylingControls: []
@@ -203,7 +202,7 @@ class Editor extends React.Component {
     return css.resolve`
       .wrapper {
         background-color: ${theme.palette.common.white};
-        border: 1px solid #979797;
+        border: 1px solid ${theme.palette.grey[500]};
         border-radius: ${theme.shape.borderRadius.md};
         font-family: ${theme.typography.body1.fontFamily};
         font-size: ${theme.typography.body1.fontSize};
@@ -265,8 +264,8 @@ class Editor extends React.Component {
         flex-direction: row;
         justify-content: space-between;
         padding-left: ${theme.spacing(2)}px;
-        border-bottom-left-radius: 4px;
-        border-bottom-right-radius: 4px;
+        border-bottom-left-radius: ${theme.shape.borderRadius.md};
+        border-bottom-right-radius: ${theme.shape.borderRadius.md};
       }
 
       .stylingControls > div:not(:last-child) {
@@ -398,6 +397,8 @@ class Editor extends React.Component {
       this.editor.current.focus();
     }
   };
+
+  forceFocus = () => focus(true);
 
   // Control button callback for toggling block type
   toggleBlockType = blockType => {
@@ -649,7 +650,7 @@ class Editor extends React.Component {
 
     return (
       <React.Fragment>
-        <div className={wrapperClasses} onClick={() => this.focus(true)}>
+        <div className={wrapperClasses} onClick={this.forceFocus}>
           {controlPosition === "top" && this.renderControls()}
           <div className={editorClasses} style={style}>
             <DraftJsEditor


### PR DESCRIPTION
## Description
design:
![Screen Shot 2020-12-04 at 13 59 08](https://user-images.githubusercontent.com/4382804/101219228-e8660280-3638-11eb-967d-62f656b651c4.png)

Main changes:
No border - use colour difference instead
Ability to add left justified actions
Ability to add control row full height actions

## Notes
Have to update a couple places the editor is used on the web app where the prop naming has changed, but other than that its a minor change

## Screenshots
![Screen Shot 2020-12-04 at 13 51 58](https://user-images.githubusercontent.com/4382804/101219518-016eb380-3639-11eb-9335-6f27c6391298.png)
