### PR TITLE
Update hover functionality in Chip component

### DIFF
--- a/packages/riipen-ui-docs/src/pages/components/chip/Click.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/chip/Click.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+import Chip from "riipen-ui/components/Chip";
+
+export default function Click() {
+  const clicked = () => {
+    // eslint-disable-next-line no-alert
+    alert("Clicked");
+  };
+
+  return <Chip onClick={clicked} color="secondary" label="Click Me" />;
+}

--- a/packages/riipen-ui-docs/src/pages/components/chip/Hover.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/chip/Hover.jsx
@@ -28,6 +28,26 @@ export default function Hover() {
         <Chip label="Warning" hover color="warning" />
         <span style={style} />
         <Chip label="Negative" hover color="negative" />
+        <span style={style} />
+        <Chip label="Dark" hover color="dark" />
+      </div>
+      <div style={breakStyle}>
+        <Chip label="Default" hover variant="outlined" />
+        <span style={style} />
+        <Chip label="Primary" hover color="primary" variant="outlined" />
+        <span style={style} />
+        <Chip label="Secondary" hover color="secondary" variant="outlined" />
+        <span style={style} />
+        <Chip label="Tertiary" hover color="tertiary" variant="outlined" />
+      </div>
+      <div style={breakStyle}>
+        <Chip label="Positive" hover color="positive" variant="outlined" />
+        <span style={style} />
+        <Chip label="Warning" hover color="warning" variant="outlined" />
+        <span style={style} />
+        <Chip label="Negative" hover color="negative" variant="outlined" />
+        <span style={style} />
+        <Chip label="Dark" hover color="dark" variant="outlined" />
       </div>
     </div>
   );

--- a/packages/riipen-ui-docs/src/pages/components/chip/Icon.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/chip/Icon.jsx
@@ -24,17 +24,17 @@ export default function Icons() {
   return (
     <div>
       <div>
-        <Chip iconStart={icon(faPlus)} color="primary" label="Icon Start" />
+        <Chip icon={icon(faPlus)} color="primary" label="Icon Start" />
         <span style={style} />
         <Chip
-          iconStart={icon(faTimes)}
+          icon={icon(faTimes)}
           onIconClick={iconClicked}
           color="secondary"
           label="Icon Click"
         />
         <span style={style} />
         <Chip
-          iconStart={icon(faExclamationCircle)}
+          icon={icon(faExclamationCircle)}
           disabled
           onIconClick={iconClicked}
           color="secondary"

--- a/packages/riipen-ui-docs/src/pages/components/chip/chip.md
+++ b/packages/riipen-ui-docs/src/pages/components/chip/chip.md
@@ -32,9 +32,15 @@ If you need a more condensed view of the pill, use the `size` prop.
 
 {{"demo": "pages/components/chip/Compact.js"}}
 
+## Click
+
+If you need to allow people to perform actions an `onClick` event can be provided.
+
+{{"demo": "pages/components/chip/Click.js"}}
+
 ## Icon
 
-If you need to allow people to perform actions an `iconStart` with/without an `onIconClick` event can be provided
+If you need to allow people to perform actions an `icon` with/without an `onIconClick` event can be provided
 
 {{"demo": "pages/components/chip/Icon.js"}}
 

--- a/packages/riipen-ui/src/components/Chip.jsx
+++ b/packages/riipen-ui/src/components/Chip.jsx
@@ -180,8 +180,8 @@ class Chip extends React.Component {
             cursor: pointer;
           }
           .root.hover:hover {
-            border-color: ${theme.palette.grey[400]};
-            background-color: ${theme.palette.grey[400]};
+            background-color: transparent;
+            border: 1px solid ${theme.palette.text.primary};
           }
           .icon-start {
             align-items: center;
@@ -210,8 +210,8 @@ class Chip extends React.Component {
             color: ${theme.palette.primary.contrast};
           }
           .primary.hover:hover {
-            background-color: ${theme.palette.primary.dark};
-            border-color: ${theme.palette.primary.dark};
+            border-color: ${theme.palette.primary.main};
+            color: ${theme.palette.primary.main};
           }
           .primary.outlined {
             border-color: ${theme.palette.primary.main};
@@ -229,8 +229,8 @@ class Chip extends React.Component {
             color: ${theme.palette.secondary.contrast};
           }
           .secondary.hover:hover {
-            background-color: ${theme.palette.secondary.dark};
-            border-color: ${theme.palette.secondary.dark};
+            border-color: ${theme.palette.secondary.main};
+            color: ${theme.palette.secondary.main};
           }
           .secondary.outlined {
             border-color: ${theme.palette.secondary.main};
@@ -247,8 +247,8 @@ class Chip extends React.Component {
             color: ${theme.palette.tertiary.contrast};
           }
           .tertiary.hover:hover {
-            background-color: ${theme.palette.tertiary.dark};
-            border-color: ${theme.palette.tertiary.dark};
+            border-color: ${theme.palette.tertiary.main};
+            color: ${theme.palette.tertiary.main};
           }
           .tertiary.outlined {
             border-color: ${theme.palette.tertiary.main};
@@ -265,8 +265,8 @@ class Chip extends React.Component {
             color: ${theme.palette.negative.contrast};
           }
           .negative.hover:hover {
-            background-color: ${theme.palette.negative.dark};
-            border-color: ${theme.palette.negative.dark};
+            border-color: ${theme.palette.negative.main};
+            color: ${theme.palette.negative.main};
           }
           .negative.outlined {
             border-color: ${theme.palette.negative.main};
@@ -283,8 +283,8 @@ class Chip extends React.Component {
             color: ${theme.palette.warning.contrast};
           }
           .warning.hover:hover {
-            background-color: ${theme.palette.warning.dark};
-            border-color: ${theme.palette.warning.dark};
+            border-color: ${theme.palette.warning.main};
+            color: ${theme.palette.warning.main};
           }
           .warning.outlined {
             border-color: ${theme.palette.warning.main};
@@ -301,8 +301,8 @@ class Chip extends React.Component {
             color: ${theme.palette.positive.contrast};
           }
           .positive.hover:hover {
-            background-color: ${theme.palette.positive.dark};
-            border-color: ${theme.palette.positive.dark};
+            border-color: ${theme.palette.positive.main};
+            color: ${theme.palette.positive.main};
           }
           .positive.outlined {
             border-color: ${theme.palette.positive.main};
@@ -319,8 +319,7 @@ class Chip extends React.Component {
             color: ${theme.palette.common.white};
           }
           .dark.hover:hover {
-            background-color: ${theme.palette.common.white};
-            border-color: ${theme.palette.common.white};
+            border-color: ${theme.palette.grey.A400};
             color: ${theme.palette.grey.A400};
           }
           .dark.outlined {

--- a/packages/riipen-ui/src/components/Chip.jsx
+++ b/packages/riipen-ui/src/components/Chip.jsx
@@ -45,6 +45,11 @@ class Chip extends React.Component {
     disabled: PropTypes.bool,
 
     /**
+     * Whether the chip should invert its variant on hover.
+     */
+    hover: PropTypes.bool,
+
+    /**
      * Icon to display at start of chip.
      */
     icon: PropTypes.elementType,
@@ -80,6 +85,7 @@ class Chip extends React.Component {
     color: "default",
     component: "div",
     disabled: false,
+    hover: false,
     size: "medium",
     variant: "default"
   };
@@ -92,6 +98,7 @@ class Chip extends React.Component {
       color,
       component: Component,
       disabled,
+      hover,
       icon: Icon,
       onIconClick,
       onClick,
@@ -113,7 +120,8 @@ class Chip extends React.Component {
       size,
       variant,
       classes,
-      { clickable }
+      { clickable },
+      hover ? "hover" : null
     );
 
     const handleClick = () => {
@@ -171,7 +179,10 @@ class Chip extends React.Component {
           .root.clickable {
             cursor: pointer;
           }
-
+          .root.hover:hover {
+            border-color: ${theme.palette.grey[400]};
+            background-color: ${theme.palette.grey[400]};
+          }
           .icon-start {
             align-items: center;
             display: flex;
@@ -198,14 +209,18 @@ class Chip extends React.Component {
             border-color: ${theme.palette.primary.main};
             color: ${theme.palette.primary.contrast};
           }
+          .primary.hover:hover {
+            background-color: ${theme.palette.primary.dark};
+            border-color: ${theme.palette.primary.dark};
+          }
           .primary.outlined {
             border-color: ${theme.palette.primary.main};
             color: ${theme.palette.primary.main};
           }
           .primary.outlined.hover:hover {
-            background-color: ${theme.palette.primary.main};
-            border-color: ${theme.palette.primary.main};
-            color: ${theme.palette.primary.contrast};
+            background-color: transparent;
+            border-color: ${theme.palette.primary.dark};
+            color: ${theme.palette.primary.dark};
           }
 
           .secondary {
@@ -213,69 +228,117 @@ class Chip extends React.Component {
             border-color: ${theme.palette.secondary.main};
             color: ${theme.palette.secondary.contrast};
           }
+          .secondary.hover:hover {
+            background-color: ${theme.palette.secondary.dark};
+            border-color: ${theme.palette.secondary.dark};
+          }
           .secondary.outlined {
             border-color: ${theme.palette.secondary.main};
             color: ${theme.palette.secondary.main};
           }
           .secondary.outlined.hover:hover {
-            background-color: ${theme.palette.secondary.main};
-            border-color: ${theme.palette.secondary.main};
-            color: ${theme.palette.secondary.contrast};
+            background-color: transparent;
+            border-color: ${theme.palette.secondary.dark};
+            color: ${theme.palette.secondary.dark};
           }
-
           .tertiary {
             background-color: ${theme.palette.tertiary.main};
             border-color: ${theme.palette.tertiary.main};
             color: ${theme.palette.tertiary.contrast};
           }
+          .tertiary.hover:hover {
+            background-color: ${theme.palette.tertiary.dark};
+            border-color: ${theme.palette.tertiary.dark};
+          }
           .tertiary.outlined {
             border-color: ${theme.palette.tertiary.main};
             color: ${theme.palette.tertiary.main};
           }
-
+          .tertiary.outlined.hover:hover {
+            background-color: transparent;
+            border-color: ${theme.palette.tertiary.dark};
+            color: ${theme.palette.tertiary.dark};
+          }
           .negative {
             background-color: ${theme.palette.negative.main};
             border-color: ${theme.palette.negative.main};
             color: ${theme.palette.negative.contrast};
           }
+          .negative.hover:hover {
+            background-color: ${theme.palette.negative.dark};
+            border-color: ${theme.palette.negative.dark};
+          }
           .negative.outlined {
             border-color: ${theme.palette.negative.main};
             color: ${theme.palette.negative.main};
           }
-
+          .negative.outlined.hover:hover {
+            background-color: transparent;
+            border-color: ${theme.palette.negative.dark};
+            color: ${theme.palette.negative.dark};
+          }
           .warning {
             background-color: ${theme.palette.warning.main};
             border-color: ${theme.palette.warning.main};
             color: ${theme.palette.warning.contrast};
           }
+          .warning.hover:hover {
+            background-color: ${theme.palette.warning.dark};
+            border-color: ${theme.palette.warning.dark};
+          }
           .warning.outlined {
             border-color: ${theme.palette.warning.main};
             color: ${theme.palette.warning.main};
           }
-
+          .warning.outlined.hover:hover {
+            background-color: transparent;
+            border-color: ${theme.palette.warning.dark};
+            color: ${theme.palette.warning.dark};
+          }
           .positive {
             background-color: ${theme.palette.positive.main};
             border-color: ${theme.palette.positive.main};
             color: ${theme.palette.positive.contrast};
           }
+          .positive.hover:hover {
+            background-color: ${theme.palette.positive.dark};
+            border-color: ${theme.palette.positive.dark};
+          }
           .positive.outlined {
             border-color: ${theme.palette.positive.main};
             color: ${theme.palette.positive.main};
           }
-
+          .positive.outlined.hover:hover {
+            background-color: transparent;
+            border-color: ${theme.palette.positive.dark};
+            color: ${theme.palette.positive.dark};
+          }
           .dark {
             background-color: ${theme.palette.grey.A400};
             border-color: ${theme.palette.grey.A400};
             color: ${theme.palette.common.white};
           }
+          .dark.hover:hover {
+            background-color: transparent;
+            border-color: transparent;
+            color: ${theme.palette.grey.A400};
+          }
           .dark.outlined {
             border-color: ${theme.palette.grey.A400};
             color: ${theme.palette.grey.A400};
           }
-
+          .dark.outlined.hover:hover {
+            border-color: ${theme.palette.grey[300]};
+            color: ${theme.palette.text.secondary};
+          }
           .outlined {
             background-color: transparent;
             border: 1px solid ${theme.palette.text.primary};
+          }
+          .outlined.default.hover:hover {
+            background-color: transparent;
+            border-color: ${theme.palette.secondary.main};
+            color: ${theme.palette.secondary.main};
           }
         `}</style>
       </React.Fragment>

--- a/packages/riipen-ui/src/components/Chip.jsx
+++ b/packages/riipen-ui/src/components/Chip.jsx
@@ -218,9 +218,9 @@ class Chip extends React.Component {
             color: ${theme.palette.primary.main};
           }
           .primary.outlined.hover:hover {
-            background-color: transparent;
-            border-color: ${theme.palette.primary.dark};
-            color: ${theme.palette.primary.dark};
+            background-color: ${theme.palette.primary.main};
+            border-color: ${theme.palette.primary.main};
+            color: ${theme.palette.primary.contrast};
           }
 
           .secondary {
@@ -237,9 +237,9 @@ class Chip extends React.Component {
             color: ${theme.palette.secondary.main};
           }
           .secondary.outlined.hover:hover {
-            background-color: transparent;
-            border-color: ${theme.palette.secondary.dark};
-            color: ${theme.palette.secondary.dark};
+            background-color: ${theme.palette.secondary.main};
+            border-color: ${theme.palette.secondary.main};
+            color: ${theme.palette.secondary.contrast};
           }
           .tertiary {
             background-color: ${theme.palette.tertiary.main};
@@ -255,9 +255,9 @@ class Chip extends React.Component {
             color: ${theme.palette.tertiary.main};
           }
           .tertiary.outlined.hover:hover {
-            background-color: transparent;
-            border-color: ${theme.palette.tertiary.dark};
-            color: ${theme.palette.tertiary.dark};
+            background-color: ${theme.palette.tertiary.main};
+            border-color: ${theme.palette.tertiary.main};
+            color: ${theme.palette.tertiary.contrast};
           }
           .negative {
             background-color: ${theme.palette.negative.main};
@@ -273,9 +273,9 @@ class Chip extends React.Component {
             color: ${theme.palette.negative.main};
           }
           .negative.outlined.hover:hover {
-            background-color: transparent;
-            border-color: ${theme.palette.negative.dark};
-            color: ${theme.palette.negative.dark};
+            background-color: ${theme.palette.negative.main};
+            border-color: ${theme.palette.negative.main};
+            color: ${theme.palette.negative.contrast};
           }
           .warning {
             background-color: ${theme.palette.warning.main};
@@ -291,9 +291,9 @@ class Chip extends React.Component {
             color: ${theme.palette.warning.main};
           }
           .warning.outlined.hover:hover {
-            background-color: transparent;
-            border-color: ${theme.palette.warning.dark};
-            color: ${theme.palette.warning.dark};
+            background-color: ${theme.palette.warning.main};
+            border-color: ${theme.palette.warning.main};
+            color: ${theme.palette.warning.contrast};
           }
           .positive {
             background-color: ${theme.palette.positive.main};
@@ -309,9 +309,9 @@ class Chip extends React.Component {
             color: ${theme.palette.positive.main};
           }
           .positive.outlined.hover:hover {
-            background-color: transparent;
-            border-color: ${theme.palette.positive.dark};
-            color: ${theme.palette.positive.dark};
+            background-color: ${theme.palette.positive.main};
+            border-color: ${theme.palette.positive.main};
+            color: ${theme.palette.positive.contrast};
           }
           .dark {
             background-color: ${theme.palette.grey.A400};
@@ -319,8 +319,8 @@ class Chip extends React.Component {
             color: ${theme.palette.common.white};
           }
           .dark.hover:hover {
-            background-color: transparent;
-            border-color: transparent;
+            background-color: ${theme.palette.common.white};
+            border-color: ${theme.palette.common.white};
             color: ${theme.palette.grey.A400};
           }
           .dark.outlined {
@@ -328,17 +328,18 @@ class Chip extends React.Component {
             color: ${theme.palette.grey.A400};
           }
           .dark.outlined.hover:hover {
-            border-color: ${theme.palette.grey[300]};
-            color: ${theme.palette.text.secondary};
+            background-color: ${theme.palette.grey.A400};
+            border-color: ${theme.palette.grey.A400};
+            color: ${theme.palette.common.white};
           }
           .outlined {
             background-color: transparent;
             border: 1px solid ${theme.palette.text.primary};
           }
           .outlined.default.hover:hover {
-            background-color: transparent;
-            border-color: ${theme.palette.secondary.main};
-            color: ${theme.palette.secondary.main};
+            background-color: ${theme.palette.grey[300]};
+            border-color: ${theme.palette.grey[300]};
+            color: ${theme.palette.text.secondary};
           }
         `}</style>
       </React.Fragment>


### PR DESCRIPTION
## Description
Add section to Chip page for `onClick` prop.
Update the icon section to use `icon` prop instead of `iconStart`.
Added in the hover support.

## Notes
Not 100% on what colour we want the hover to be, maybe checkout the branch and do a look?
Also a TODO: convert to function component.

## Screenshots
![Screenshot_2020-12-07 Chip Riipen UI](https://user-images.githubusercontent.com/10818279/101400325-949c2900-3885-11eb-9a69-b59d7eb7f7a9.png)

## Where to Start
91 packages/riipen-ui/src/components/Chip.jsx