### PR TITLE
[PLT-6474] Editor: mobileControlRow prop

### DIFF
--- a/packages/riipen-ui-docs/src/pages/components-api/chip.md
+++ b/packages/riipen-ui-docs/src/pages/components-api/chip.md
@@ -25,6 +25,7 @@ You can learn more about the difference by [reading this guide](/guides/bundle-s
 | <span class="prop-name">color</span> | <span class="prop-type">"default"<br>&#124;&nbsp;"dark"<br>&#124;&nbsp;"primary"<br>&#124;&nbsp;"secondary"<br>&#124;&nbsp;"tertiary"<br>&#124;&nbsp;"positive"<br>&#124;&nbsp;"warning"<br>&#124;&nbsp;"negative"</span> | <span class="prop-default">"default"</span> | The color to use. |
 | <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">"div"</span> | The component used for the root node. Either a string to use a DOM element or a component. |
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the chip should be displayed in a disabled state. |
+| <span class="prop-name">hover</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Whether the chip should invert its variant on hover. |
 | <span class="prop-name">icon</span> | <span class="prop-type">elementType</span> |  | Icon to display at start of chip. |
 | <span class="prop-name">label</span> | <span class="prop-type">node</span> |  | The content of the label. |
 | <span class="prop-name">onClick</span> | <span class="prop-type">func</span> |  | Action to perform when clicked. |

--- a/packages/riipen-ui-docs/src/pages/components-api/editor.md
+++ b/packages/riipen-ui-docs/src/pages/components-api/editor.md
@@ -36,6 +36,7 @@ You can learn more about the difference by [reading this guide](/guides/bundle-s
   SelectionState
 } from "draft-js"; }</span> |  | The decorator for the editor. |
 | <span class="prop-name">error</span> | <span class="prop-type">any</span> |  | If the error style should be shown or not |
+| <span class="prop-name">mobileControlRow</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Whether or not to hide the controls + control row when on smaller screens. |
 | <span class="prop-name">initialValue</span> | <span class="prop-type">any</span> |  | Initial content to set in the editor |
 | <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |  | Function to execute when editor content changes, gets html value of editor |
 | <span class="prop-name">placeholder</span> | <span class="prop-type">node</span> |  | Optional placeholder. Shows when there is no text. |

--- a/packages/riipen-ui/src/components/Editor.jsx
+++ b/packages/riipen-ui/src/components/Editor.jsx
@@ -590,8 +590,6 @@ class Editor extends React.Component {
       ? ["controlContainer", "mobileControlRow"]
       : "controlContainer";
 
-    console.log({ props: this.props });
-
     return (
       <React.Fragment>
         <div className={clsx(linkedStyles.className, controlContainerClasses)}>

--- a/packages/riipen-ui/src/components/Editor.jsx
+++ b/packages/riipen-ui/src/components/Editor.jsx
@@ -132,6 +132,11 @@ class Editor extends React.Component {
     error: PropTypes.any,
 
     /**
+     * Whether or not to hide the controls + control row when on smaller screens.
+     */
+    hideControlRowOnMobile: PropTypes.bool,
+
+    /**
      * Initial content to set in the editor
      */
     initialValue: PropTypes.any,
@@ -161,6 +166,7 @@ class Editor extends React.Component {
   static defaultProps = {
     actionControls: [],
     controlPosition: "top",
+    hideControlRowOnMobile: true,
     stylingControls: []
   };
 
@@ -263,6 +269,7 @@ class Editor extends React.Component {
         flex: 1 1 auto;
         flex-direction: row;
         justify-content: space-between;
+        align-items: flex-end;
         padding-left: ${theme.spacing(2)}px;
         border-bottom-left-radius: ${theme.shape.borderRadius.md};
         border-bottom-right-radius: ${theme.shape.borderRadius.md};
@@ -273,7 +280,7 @@ class Editor extends React.Component {
       }
 
       @media (max-width: ${theme.breakpoints.sm}px) {
-        .controlContainer {
+        .controlContainer.hideControlRowOnMobile {
           display: none;
         }
 
@@ -569,14 +576,25 @@ class Editor extends React.Component {
   static contextType = ThemeContext;
 
   renderControls = () => {
-    const { stylingControls, actionControls } = this.props;
+    const {
+      stylingControls,
+      actionControls,
+      hideControlRowOnMobile
+    } = this.props;
+
     const { editorState } = this.state;
 
     const linkedStyles = this.getLinkedStyles();
 
+    const controlContainerClasses = hideControlRowOnMobile
+      ? ["controlContainer", "hideControlRowOnMobile"]
+      : "controlContainer";
+
+    console.log({ props: this.props });
+
     return (
       <React.Fragment>
-        <div className={clsx(linkedStyles.className, "controlContainer")}>
+        <div className={clsx(linkedStyles.className, controlContainerClasses)}>
           <div className={clsx(linkedStyles.className, "stylingControls")}>
             <EditorBlockStyleControls
               classes={[linkedStyles.className, "controlRow"]}

--- a/packages/riipen-ui/src/components/Editor.jsx
+++ b/packages/riipen-ui/src/components/Editor.jsx
@@ -134,7 +134,7 @@ class Editor extends React.Component {
     /**
      * Whether or not to hide the controls + control row when on smaller screens.
      */
-    hideControlRowOnMobile: PropTypes.bool,
+    mobileControlRow: PropTypes.bool,
 
     /**
      * Initial content to set in the editor
@@ -166,7 +166,7 @@ class Editor extends React.Component {
   static defaultProps = {
     actionControls: [],
     controlPosition: "top",
-    hideControlRowOnMobile: true,
+    mobileControlRow: false,
     stylingControls: []
   };
 
@@ -280,8 +280,12 @@ class Editor extends React.Component {
       }
 
       @media (max-width: ${theme.breakpoints.sm}px) {
-        .controlContainer.hideControlRowOnMobile {
+        .controlContainer {
           display: none;
+        }
+
+        .controlContainer.mobileControlRow {
+          display: flex;
         }
 
         .wrapper {
@@ -576,18 +580,14 @@ class Editor extends React.Component {
   static contextType = ThemeContext;
 
   renderControls = () => {
-    const {
-      stylingControls,
-      actionControls,
-      hideControlRowOnMobile
-    } = this.props;
+    const { stylingControls, actionControls, mobileControlRow } = this.props;
 
     const { editorState } = this.state;
 
     const linkedStyles = this.getLinkedStyles();
 
-    const controlContainerClasses = hideControlRowOnMobile
-      ? ["controlContainer", "hideControlRowOnMobile"]
+    const controlContainerClasses = mobileControlRow
+      ? ["controlContainer", "mobileControlRow"]
       : "controlContainer";
 
     console.log({ props: this.props });


### PR DESCRIPTION


## Description
* Add prop to not `display: none` controlRow when on mobile
* web -> Message/Form/New shouldn't hide the control row when on mobile https://github.com/riipen/platform-web/pull/3393
## Notes

## Screenshots
![Screen Shot 2020-12-17 at 11 34 46 AM](https://user-images.githubusercontent.com/36321777/102516033-6d4f1400-405c-11eb-9bed-02a7e7fdfdb6.png)

## Where to Start
