### PR TITLE
[PLT-4638] Add check to MenuList component for undefined child

### DIFF
--- a/packages/riipen-ui/src/components/MenuList.jsx
+++ b/packages/riipen-ui/src/components/MenuList.jsx
@@ -74,6 +74,8 @@ class MenuList extends React.Component {
     return React.Children.map(
       this.handleFragmentChildren(children),
       (child, idx) => {
+        if (!child) return null;
+
         let newProps = {
           key: idx,
           color: this.props.color


### PR DESCRIPTION
https://riipen.atlassian.net/secure/RapidBoard.jspa?rapidView=6&projectKey=PLT&modal=detail&selectedIssue=PLT-4638

## Description
The `MenuList` component crashes when passed an `undefined` item. This is a problem when we try to do something like `{course.school && .. Menu}` (or something like that) and `course.school` is `undefined`. We would like a case for this in `Menu` rather than at the higher level in platform-web. 

## Notes
We need to simply not render the undefined item. This is much more graceful than crashing the entire page.

The crash happens when a clone is attempted on the React element in question, being the list item. When the child is undefined, it attempts to clone undefined which is not a React element.

## Where to Start
Easily enough to replicate this you just have to do something like:
```js
<Menu>
  {undefined}
</Menu>
```
Previously this would crash a couple levels down when it tries to create the `undefined` item in `MenuList`.