### PR TITLE
Fix react-docgen build failure

### DIFF
--- a/packages/riipen-ui-docs/scripts/buildAPI.js
+++ b/packages/riipen-ui-docs/scripts/buildAPI.js
@@ -138,7 +138,12 @@ function getComponents(directory, components) {
     .map(item => ({
       filename: path.resolve(directory, item)
     }))
-    .filter(item => !item.filename.endsWith("/index.js"));
+    .filter(
+      item =>
+        !item.filename.endsWith("/index.js") &&
+        !item.filename.endsWith(".snap") &&
+        !item.filename.endsWith(".test.jsx")
+    );
 
   items.forEach(item => {
     if (!item.filename.endsWith(".jsx")) {

--- a/packages/riipen-ui/src/components/ListItem.jsx
+++ b/packages/riipen-ui/src/components/ListItem.jsx
@@ -39,6 +39,10 @@ const ListItem = props => {
     "list-item"
   );
 
+  const focusColour = (
+    theme.palette[color] || theme.palette[ListItem.defaultProps.color]
+  ).main;
+
   return (
     <React.Fragment>
       <div
@@ -64,8 +68,7 @@ const ListItem = props => {
         }
 
         .list-item.focusVisible {
-          color: ${theme.palette[color]?.main} ||
-            ${theme.palette[ListItem.defaultProps.color].main};
+          color: ${focusColour};
           outline: 5px auto -webkit-focus-ring-color;
         }
       `}</style>


### PR DESCRIPTION
## Description
Im not entirely sure what cause it, but it looks like react-docgen really doesnt like the test / snapshot files. I've updated the build script to omit those.
Additionally it no longer likes optional chaining (the `x?.y` syntax) so i've tweaked the ListItem component a bit. (thankfully the only place it was being used)

I want to figure the chaining one out as we should be able to use that, but at least this builds


## Notes

## Screenshots

## Where to Start
