### PR TITLE
Firefox style change to make outline visible on tab event

### DIFF
--- a/packages/riipen-ui/src/components/Checkbox.jsx
+++ b/packages/riipen-ui/src/components/Checkbox.jsx
@@ -111,7 +111,7 @@ const Checkbox = props => {
         }
 
         label input.focusVisible ~ .checkmark {
-          outline: -webkit-focus-ring-color auto 5px;
+          outline: auto 5px;
         }
 
         /* When the checkbox is checked */

--- a/packages/riipen-ui/src/components/Checkbox.jsx
+++ b/packages/riipen-ui/src/components/Checkbox.jsx
@@ -33,10 +33,10 @@ const Checkbox = props => {
     onBlurVisible();
   };
 
-  const handleKeyDown = e => {
+  const handleKeyDown = e => {    
     if (e.key === "Enter") {
       e.target.checked = !checked;
-      other.onChange(e);
+      other.onChange?.(e);
     }
   };
 

--- a/packages/riipen-ui/src/components/Checkbox.jsx
+++ b/packages/riipen-ui/src/components/Checkbox.jsx
@@ -212,7 +212,7 @@ Checkbox.propTypes = {
   /**
    * A warning to display below the checkbox.
    */
-  warning: PropTypes.node,
+  warning: PropTypes.node
 };
 
 Checkbox.defaultProps = {

--- a/packages/riipen-ui/src/components/Checkbox.jsx
+++ b/packages/riipen-ui/src/components/Checkbox.jsx
@@ -33,6 +33,13 @@ const Checkbox = props => {
     onBlurVisible();
   };
 
+  const handleKeyDown = e => {
+    if (e.key === "Enter") {
+      e.target.checked = !checked;
+      other.onChange(e);
+    }
+  };
+
   const className = clsx("checkbox", focusVisible ? "focusVisible" : null);
 
   return (
@@ -50,6 +57,7 @@ const Checkbox = props => {
           type="checkbox"
           onFocus={handleFocus}
           onBlur={handleBlur}
+          onKeyDown={handleKeyDown}
           {...other}
         />
         <span
@@ -204,7 +212,7 @@ Checkbox.propTypes = {
   /**
    * A warning to display below the checkbox.
    */
-  warning: PropTypes.node
+  warning: PropTypes.node,
 };
 
 Checkbox.defaultProps = {

--- a/packages/riipen-ui/src/components/Checkbox.test.jsx
+++ b/packages/riipen-ui/src/components/Checkbox.test.jsx
@@ -211,4 +211,16 @@ describe("<Checkbox>", () => {
       ).toEqual(false);
     });
   });
+
+  describe("onKeyDown event", () => {
+  it("invokes handleKeyDown on valid keydown event", () => {
+    const handler = jest.fn();
+
+    const wrapper = mount(<Checkbox onKeyDown={handler} readOnly />);
+
+    wrapper.find("input").simulate("keydown", { key: "Enter" });
+
+   expect(handler).toHaveBeenCalledTimes(1);
+  });
+});
 });

--- a/packages/riipen-ui/src/components/Checkbox.test.jsx
+++ b/packages/riipen-ui/src/components/Checkbox.test.jsx
@@ -213,14 +213,14 @@ describe("<Checkbox>", () => {
   });
 
   describe("onKeyDown event", () => {
-  it("invokes handleKeyDown on valid keydown event", () => {
-    const handler = jest.fn();
+    it("invokes handleKeyDown on valid keydown event", () => {
+      const handler = jest.fn();
 
-    const wrapper = mount(<Checkbox onKeyDown={handler} readOnly />);
+      const wrapper = mount(<Checkbox onKeyDown={handler} readOnly />);
 
-    wrapper.find("input").simulate("keydown", { key: "Enter" });
+      wrapper.find("input").simulate("keydown", { key: "Enter" });
 
-   expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
   });
-});
 });

--- a/packages/riipen-ui/src/components/__snapshots__/Checkbox.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Checkbox.test.jsx.snap
@@ -320,6 +320,7 @@ exports[`<Checkbox> renders correct snapshot 1`] = `
           disabled={false}
           onBlur={[Function]}
           onFocus={[Function]}
+          onKeyDown={[Function]}
           readOnly={true}
           type="checkbox"
         />


### PR DESCRIPTION
## Description
Outline now appears in Firefox when Checkbox is tabbed to. Let me know if there are further style changes needed.

## Where to Start
Checkbox.jsx