### PR TITLE
Allow buttons to take icons and components that render icons

### DIFF
--- a/packages/riipen-ui-docs/src/pages/components/button/Icons.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/button/Icons.jsx
@@ -3,8 +3,6 @@ import React from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChevronRight, faTrash } from "@fortawesome/free-solid-svg-icons";
 
-const icon = i => props => <FontAwesomeIcon icon={i} {...props} />;
-
 import Button from "riipen-ui/components/Button";
 import ButtonIcon from "riipen-ui/components/ButtonIcon";
 
@@ -15,13 +13,17 @@ export default function Icons() {
 
   return (
     <div>
-      <Button color="default" iconStart={icon(faTrash)} variant="contained">
+      <Button
+        color="default"
+        iconStart={<FontAwesomeIcon icon={faTrash} />}
+        variant="contained"
+      >
         Delete
       </Button>
       <span style={style} />
       <Button
         color="default"
-        iconEnd={icon(faChevronRight)}
+        iconEnd={<FontAwesomeIcon icon={faChevronRight} />}
         variant="contained"
       >
         Continue

--- a/packages/riipen-ui/package.json
+++ b/packages/riipen-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riipen-ui",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "private": false,
   "author": {
     "name": "Riipen",

--- a/packages/riipen-ui/src/components/Button.jsx
+++ b/packages/riipen-ui/src/components/Button.jsx
@@ -65,13 +65,13 @@ const Button = props => {
         <span className={clsx("label")}>
           {IconStart && (
             <span className={clsx("icon", "icon-start")}>
-              <IconStart />
+              {typeof IconStart === "function" ? <IconStart /> : IconStart}
             </span>
           )}
           {children}
           {IconEnd && (
             <span className={clsx("icon", "icon-end")}>
-              <IconEnd />
+              {typeof IconEnd === "function" ? <IconEnd /> : IconEnd}
             </span>
           )}
         </span>
@@ -463,12 +463,12 @@ Button.propTypes = {
   /**
    * Element placed after the children.
    */
-  iconEnd: PropTypes.elementType,
+  iconEnd: PropTypes.oneOfType([PropTypes.elementType, PropTypes.node]),
 
   /**
    * Element placed before the children.
    */
-  iconStart: PropTypes.elementType,
+  iconStart: PropTypes.oneOfType([PropTypes.elementType, PropTypes.node]),
 
   /**
    * The size of the chip.

--- a/packages/riipen-ui/src/components/Button.test.jsx
+++ b/packages/riipen-ui/src/components/Button.test.jsx
@@ -185,7 +185,7 @@ describe("<Button>", () => {
       ).toEqual(true);
     });
 
-    it("renders iconEnd", () => {
+    it("renders iconEnd with a component icon", () => {
       const iconEnd = icon(faTrash);
 
       const wrapper = mount(<Button iconEnd={iconEnd} />);
@@ -194,6 +194,19 @@ describe("<Button>", () => {
         wrapper
           .find(".icon-end")
           .childAt(0)
+          .childAt(0)
+          .name()
+      ).toEqual("FontAwesomeIcon");
+    });
+
+    it("renders iconEnd with a jsx icon", () => {
+      const wrapper = mount(
+        <Button iconEnd={<FontAwesomeIcon icon={faTrash} />} />
+      );
+
+      expect(
+        wrapper
+          .find(".icon-end")
           .childAt(0)
           .name()
       ).toEqual("FontAwesomeIcon");
@@ -214,7 +227,7 @@ describe("<Button>", () => {
       ).toEqual(true);
     });
 
-    it("renders iconStart", () => {
+    it("renders iconStart with a component icon", () => {
       const iconStart = icon(faTrash);
 
       const wrapper = mount(<Button iconStart={iconStart} />);
@@ -223,6 +236,19 @@ describe("<Button>", () => {
         wrapper
           .find(".icon-start")
           .childAt(0)
+          .childAt(0)
+          .name()
+      ).toEqual("FontAwesomeIcon");
+    });
+
+    it("renders iconStart with a jsx icon", () => {
+      const wrapper = mount(
+        <Button iconStart={<FontAwesomeIcon icon={faTrash} />} />
+      );
+
+      expect(
+        wrapper
+          .find(".icon-start")
           .childAt(0)
           .name()
       ).toEqual("FontAwesomeIcon");


### PR DESCRIPTION
## Description

Allow the button to render icons directly instead of having to pass a component in

## Notes

## Screenshots

## Where to Start
