### PR TITLE
Chip Icon

### DIFF
--- a/packages/riipen-ui-docs/src/pages/components/chip/Icon.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/chip/Icon.jsx
@@ -1,15 +1,12 @@
-import React from "react";
-
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faTimes,
   faPlus,
   faExclamationCircle
 } from "@fortawesome/free-solid-svg-icons";
+import React from "react";
 
 import Chip from "riipen-ui/components/Chip";
-
-const icon = i => props => <FontAwesomeIcon icon={i} {...props} />;
 
 export default function Icons() {
   const style = {
@@ -19,12 +16,20 @@ export default function Icons() {
   return (
     <div>
       <div>
-        <Chip icon={icon(faPlus)} color="primary" label="Icon Start" />
-        <span style={style} />
-        <Chip icon={icon(faTimes)} color="secondary" label="Icon" />
+        <Chip
+          icon={<FontAwesomeIcon icon={faPlus} />}
+          color="primary"
+          label="Icon Start"
+        />
         <span style={style} />
         <Chip
-          icon={icon(faExclamationCircle)}
+          icon={<FontAwesomeIcon icon={faTimes} />}
+          color="secondary"
+          label="Icon"
+        />
+        <span style={style} />
+        <Chip
+          icon={<FontAwesomeIcon icon={faExclamationCircle} />}
           disabled
           color="secondary"
           label="Icon Disabled"

--- a/packages/riipen-ui/src/components/Chip.jsx
+++ b/packages/riipen-ui/src/components/Chip.jsx
@@ -53,7 +53,7 @@ class Chip extends React.Component {
     /**
      * Icon to display at start of chip.
      */
-    icon: PropTypes.elementType,
+    icon: PropTypes.node,
 
     /**
      * The content of the label.
@@ -95,7 +95,7 @@ class Chip extends React.Component {
       component: Component,
       disabled,
       hover,
-      icon: Icon,
+      icon,
       onClick,
       size,
       variant
@@ -125,11 +125,7 @@ class Chip extends React.Component {
     return (
       <React.Fragment>
         <Component onClick={handleClick} className={className}>
-          {Icon && (
-            <span className={clsx("icon", "icon-start")}>
-              <Icon />
-            </span>
-          )}
+          {icon && <span className="icon">{icon}</span>}
           <span className={clsx("label")}>{label}</span>
         </Component>
         <style jsx>{`
@@ -172,14 +168,14 @@ class Chip extends React.Component {
             background-color: transparent;
             border: 1px solid ${theme.palette.text.primary};
           }
-          .icon-start {
+          .icon {
             align-items: center;
             display: flex;
             padding-right: 10px;
             white-space: nowrap;
           }
 
-          .icon-start.disabled {
+          .icon.disabled {
             cursor: initial;
           }
 

--- a/packages/riipen-ui/src/components/Chip.test.jsx
+++ b/packages/riipen-ui/src/components/Chip.test.jsx
@@ -204,27 +204,17 @@ describe("<Chip>", () => {
   });
 
   describe("icon prop", () => {
-    it("displays icon with valid custom elementType", () => {
-      const icon = "a";
+    it("displays icon when given", () => {
+      const icon = <span>{"icon"}</span>;
 
       const wrapper = mount(<Chip icon={icon} />);
 
-      expect(wrapper.find(icon)).toHaveLength(1);
       expect(
         wrapper
           .find(".icon")
-          .childAt(0)
-          .name()
-      ).toEqual(icon);
-    });
-
-    it("gives an error given an invalid icon type", () => {
-      const errors = jest.spyOn(console, "error").mockImplementation();
-      const icon = "aaaaaaaaa";
-
-      mount(<Chip icon={icon} />);
-
-      expect(errors).toHaveBeenCalledTimes(1);
+          .children()
+          .contains(icon)
+      ).toEqual(true);
     });
   });
 

--- a/packages/riipen-ui/src/components/__snapshots__/Chip.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Chip.test.jsx.snap
@@ -17,11 +17,11 @@ exports[`<Chip> renders correct snapshot 1`] = `
     variant="default"
   >
     <div
-      className="jsx-3261788765 root default medium default riipen riipen-chip"
+      className="jsx-2710338002 root default medium default riipen riipen-chip"
       onClick={[Function]}
     >
       <span
-        className="jsx-3261788765 label"
+        className="jsx-2710338002 label"
       />
     </div>
     <JSXStyle
@@ -110,7 +110,7 @@ exports[`<Chip> renders correct snapshot 1`] = `
           "#747474",
         ]
       }
-      id="3718248004"
+      id="3988967785"
     />
   </Chip>
 </withClasses(Chip)>


### PR DESCRIPTION
## Description

1. Chip icon now accepts any prop type

## Notes

This is to make `<Chip>` more conducive to inversion of control.
