### PR TITLE
[PLT-7175] Add scroll bar to Editor text area

### DIFF
--- a/packages/riipen-ui-docs/src/pages/components/rich-text-editor/Usage.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/rich-text-editor/Usage.jsx
@@ -31,6 +31,12 @@ export default function Usage() {
       />
       <div style={style} />
       <RichTextEditor
+        id="editor-max-height"
+        label="Max Height"
+        maxHeight="200px"
+      />
+      <div style={style} />
+      <RichTextEditor
         id="editor-placeholder"
         label="Placeholder"
         placeholder="I'm holding the place!"

--- a/packages/riipen-ui/src/components/Editor.jsx
+++ b/packages/riipen-ui/src/components/Editor.jsx
@@ -115,13 +115,13 @@ class Editor extends React.Component {
     ariaLabelledBy: PropTypes.string,
 
     /**
-     * Optional array of whitelisted styles
+     * Optional array of whitelisted styles.
      * ex. ['code-block', 'BOLD', 'LINK']
      */
     controlWhitelist: PropTypes.arrayOf(PropTypes.string),
 
     /**
-     * Position of controls for the editor
+     * Position of controls for the editor.
      */
     controlPosition: PropTypes.oneOf(["top", "bottom"]),
 
@@ -131,7 +131,7 @@ class Editor extends React.Component {
     decorator: PropTypes.shape({ type: PropTypes.oneOf([CompositeDecorator]) }),
 
     /**
-     * If the error style should be shown or not
+     * If the error style should be shown or not.
      */
     error: PropTypes.any,
 
@@ -141,14 +141,19 @@ class Editor extends React.Component {
     mobileControlRow: PropTypes.bool,
 
     /**
-     * Initial content to set in the editor
+     * Initial content to set in the editor.
      */
     initialValue: PropTypes.any,
 
     /**
-     * Function to execute when editor content changes, gets html value of editor
+     * Function to execute when editor content changes, gets html value of editor.
      */
     onChange: PropTypes.func,
+
+    /**
+     * The max height of the Editor text area.
+     */
+    maxHeight: PropTypes.number,
 
     /**
      * Optional placeholder. Shows when there is no text.
@@ -207,7 +212,7 @@ class Editor extends React.Component {
 
   getLinkedStyles = () => {
     const theme = this.context;
-    const { controlPosition } = this.props;
+    const { controlPosition, maxHeight } = this.props;
 
     return css.resolve`
       .wrapper {
@@ -256,9 +261,9 @@ class Editor extends React.Component {
         font-size: ${theme.typography.body1.fontSize};
 
         /* 80px - 2 * 1px borders  */
-        max-height: 300px;
+        max-height: ${maxHeight || "auto"};
         min-height: 78px;
-        overflow-y: scroll;
+        overflow-y: auto;
         padding: ${theme.spacing(3)}px;
         transition: ${theme.transitions.duration.standard}ms all;
       }

--- a/packages/riipen-ui/src/components/Editor.jsx
+++ b/packages/riipen-ui/src/components/Editor.jsx
@@ -153,7 +153,7 @@ class Editor extends React.Component {
     /**
      * The max height of the Editor text area.
      */
-    maxHeight: PropTypes.number,
+    maxHeight: PropTypes.string,
 
     /**
      * Optional placeholder. Shows when there is no text.
@@ -175,6 +175,7 @@ class Editor extends React.Component {
   static defaultProps = {
     actionControls: [],
     controlPosition: "top",
+    maxHeight: "auto",
     mobileControlRow: false,
     stylingControls: []
   };
@@ -261,7 +262,7 @@ class Editor extends React.Component {
         font-size: ${theme.typography.body1.fontSize};
 
         /* 80px - 2 * 1px borders  */
-        max-height: ${maxHeight || "auto"};
+        max-height: ${maxHeight};
         min-height: 78px;
         overflow-y: auto;
         padding: ${theme.spacing(3)}px;

--- a/packages/riipen-ui/src/components/Editor.jsx
+++ b/packages/riipen-ui/src/components/Editor.jsx
@@ -256,8 +256,9 @@ class Editor extends React.Component {
         font-size: ${theme.typography.body1.fontSize};
 
         /* 80px - 2 * 1px borders  */
+        max-height: 300px;
         min-height: 78px;
-        overflow: auto;
+        overflow-y: scroll;
         padding: ${theme.spacing(3)}px;
         transition: ${theme.transitions.duration.standard}ms all;
       }

--- a/packages/riipen-ui/src/components/RichTextEditor.jsx
+++ b/packages/riipen-ui/src/components/RichTextEditor.jsx
@@ -44,6 +44,11 @@ class RichTextEditor extends React.Component {
     label: PropTypes.string,
 
     /**
+     * The max height of the Editor text area.
+     */
+    maxHeight: PropTypes.number,
+
+    /**
      * A warning to display below the input.
      */
     warning: PropTypes.node
@@ -61,6 +66,7 @@ class RichTextEditor extends React.Component {
       label,
       id,
       isRequired,
+      maxHeight,
       warning,
       ...other
     } = this.props;
@@ -76,6 +82,7 @@ class RichTextEditor extends React.Component {
         <Editor
           ariaLabelledBy={ariaLabel}
           error={error}
+          maxHeight={maxHeight}
           ref={forwardedRef}
           {...other}
         />

--- a/packages/riipen-ui/src/components/RichTextEditor.jsx
+++ b/packages/riipen-ui/src/components/RichTextEditor.jsx
@@ -46,7 +46,7 @@ class RichTextEditor extends React.Component {
     /**
      * The max height of the Editor text area.
      */
-    maxHeight: PropTypes.number,
+    maxHeight: PropTypes.string,
 
     /**
      * A warning to display below the input.
@@ -55,7 +55,8 @@ class RichTextEditor extends React.Component {
   };
 
   static defaultProps = {
-    isRequired: false
+    isRequired: false,
+    maxHeight: "auto"
   };
 
   render() {


### PR DESCRIPTION
## Description
Added max height and scroll bar to stop text overflow.

## Screenshots
<img width="637" alt="Screen Shot 2021-03-26 at 4 19 31 PM" src="https://user-images.githubusercontent.com/61811702/112701957-410f1480-8e4f-11eb-9d3a-a4730cfd166e.png">

## Where to Start
packages/riipen-ui/src/components/Editor.jsx
