### PR TITLE
Add typography warning colour

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "format": "lerna run format",
     "lint": "lerna run lint",
     "start": "lerna --scope riipen-ui-docs run start --stream",
-    "test": "jest --max-old-space-size=6144"
+    "test": "jest --max-old-space-size=6144",
+    "test:update-snapshots": "jest -u"
   },
   "husky": {
     "hooks": {

--- a/packages/riipen-ui-docs/src/pages/components/typography/Color.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/typography/Color.jsx
@@ -35,6 +35,9 @@ export default function Color() {
       <Typography color="negative" gutter>
         Negative
       </Typography>
+      <Typography color="warning" gutter>
+        Warning
+      </Typography>
       <div style={{ backgroundColor: "#000" }}>
         <Typography color="white" gutter>
           White

--- a/packages/riipen-ui/package.json
+++ b/packages/riipen-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riipen-ui",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "private": false,
   "author": {
     "name": "Riipen",

--- a/packages/riipen-ui/src/components/Typography.jsx
+++ b/packages/riipen-ui/src/components/Typography.jsx
@@ -48,6 +48,7 @@ class Typography extends React.Component {
       "primary",
       "secondary",
       "tertiary",
+      "warning",
       "white"
     ]),
 
@@ -279,6 +280,9 @@ class Typography extends React.Component {
           }
           .color-negative {
             color: ${theme.palette.negative.main};
+          }
+          .color-warning {
+            color: ${theme.palette.warning.main};
           }
           .color-white {
             color: ${theme.palette.common.white};

--- a/packages/riipen-ui/src/components/__snapshots__/Breadcrumbs.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Breadcrumbs.test.jsx.snap
@@ -31,7 +31,7 @@ exports[`<Breadcrumbs> renders correct snapshot 1`] = `
         variant="body1"
       >
         <nav
-          className="jsx-3017984631 root color-inherit initial body1 align-inherit transform-inherit riipen riipen-typography"
+          className="jsx-3132880061 root color-inherit initial body1 align-inherit transform-inherit riipen riipen-typography"
         >
           <ol
             className="jsx-2183045356 riipen riipen-breadcrumbs"
@@ -106,6 +106,7 @@ exports[`<Breadcrumbs> renders correct snapshot 1`] = `
               "#3caabb",
               "#4cc88d",
               "#e95353",
+              "#febb46",
               "#fff",
               700,
               300,
@@ -113,7 +114,7 @@ exports[`<Breadcrumbs> renders correct snapshot 1`] = `
               400,
             ]
           }
-          id="3990007342"
+          id="1786047853"
         />
       </Typography>
     </withClasses(Typography)>

--- a/packages/riipen-ui/src/components/__snapshots__/Checkbox.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Checkbox.test.jsx.snap
@@ -242,7 +242,7 @@ exports[`<Checkbox> renders correct snapshot 1`] = `
             variant="body1"
           >
             <p
-              className="jsx-3017984631 root color-inherit initial body1 align-inherit transform-inherit riipen riipen-typography"
+              className="jsx-3132880061 root color-inherit initial body1 align-inherit transform-inherit riipen riipen-typography"
             />
             <JSXStyle
               dynamic={
@@ -304,6 +304,7 @@ exports[`<Checkbox> renders correct snapshot 1`] = `
                   "#3caabb",
                   "#4cc88d",
                   "#e95353",
+                  "#febb46",
                   "#fff",
                   700,
                   300,
@@ -311,7 +312,7 @@ exports[`<Checkbox> renders correct snapshot 1`] = `
                   400,
                 ]
               }
-              id="3990007342"
+              id="1786047853"
             />
           </Typography>
         </withClasses(Typography)>

--- a/packages/riipen-ui/src/components/__snapshots__/InputHint.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/InputHint.test.jsx.snap
@@ -32,7 +32,7 @@ exports[`<InputHint> renders correct snapshot 1`] = `
           variant="body2"
         >
           <p
-            className="jsx-3017984631 root color-inherit initial body2 align-inherit transform-inherit riipen riipen-typography"
+            className="jsx-3132880061 root color-inherit initial body2 align-inherit transform-inherit riipen riipen-typography"
           />
           <JSXStyle
             dynamic={
@@ -94,6 +94,7 @@ exports[`<InputHint> renders correct snapshot 1`] = `
                 "#3caabb",
                 "#4cc88d",
                 "#e95353",
+                "#febb46",
                 "#fff",
                 700,
                 300,
@@ -101,7 +102,7 @@ exports[`<InputHint> renders correct snapshot 1`] = `
                 400,
               ]
             }
-            id="3990007342"
+            id="1786047853"
           />
         </Typography>
       </withClasses(Typography)>

--- a/packages/riipen-ui/src/components/__snapshots__/Radio.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Radio.test.jsx.snap
@@ -53,7 +53,7 @@ exports[`<Radio> renders correct snapshot 1`] = `
             variant="body1"
           >
             <p
-              className="jsx-3017984631 root color-inherit initial body1 align-inherit transform-inherit riipen riipen-typography jsx-835554889"
+              className="jsx-3132880061 root color-inherit initial body1 align-inherit transform-inherit riipen riipen-typography jsx-835554889"
             >
               <JSXStyle
                 dynamic={
@@ -126,6 +126,7 @@ exports[`<Radio> renders correct snapshot 1`] = `
                   "#3caabb",
                   "#4cc88d",
                   "#e95353",
+                  "#febb46",
                   "#fff",
                   700,
                   300,
@@ -133,7 +134,7 @@ exports[`<Radio> renders correct snapshot 1`] = `
                   400,
                 ]
               }
-              id="3990007342"
+              id="1786047853"
             />
           </Typography>
         </withClasses(Typography)>

--- a/packages/riipen-ui/src/components/__snapshots__/RadioButton.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/RadioButton.test.jsx.snap
@@ -39,7 +39,7 @@ exports[`<RadioButton> renders correct snapshot 1`] = `
             variant="body2"
           >
             <p
-              className="jsx-3017984631 root color-grey600 initial body2 align-inherit transform-inherit riipen riipen-typography"
+              className="jsx-3132880061 root color-grey600 initial body2 align-inherit transform-inherit riipen riipen-typography"
             >
               <span
                 className="jsx-1306841623 content"
@@ -105,6 +105,7 @@ exports[`<RadioButton> renders correct snapshot 1`] = `
                   "#3caabb",
                   "#4cc88d",
                   "#e95353",
+                  "#febb46",
                   "#fff",
                   700,
                   300,
@@ -112,7 +113,7 @@ exports[`<RadioButton> renders correct snapshot 1`] = `
                   400,
                 ]
               }
-              id="3990007342"
+              id="1786047853"
             />
           </Typography>
         </withClasses(Typography)>

--- a/packages/riipen-ui/src/components/__snapshots__/RadioButtonGroup.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/RadioButtonGroup.test.jsx.snap
@@ -67,7 +67,7 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
                     variant="body2"
                   >
                     <p
-                      className="jsx-3017984631 root color-grey600 initial body2 align-inherit transform-inherit riipen riipen-typography"
+                      className="jsx-3132880061 root color-grey600 initial body2 align-inherit transform-inherit riipen riipen-typography"
                     >
                       <span
                         className="jsx-1306841623 content"
@@ -133,6 +133,7 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
                           "#3caabb",
                           "#4cc88d",
                           "#e95353",
+                          "#febb46",
                           "#fff",
                           700,
                           300,
@@ -140,7 +141,7 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
                           400,
                         ]
                       }
-                      id="3990007342"
+                      id="1786047853"
                     />
                   </Typography>
                 </withClasses(Typography)>

--- a/packages/riipen-ui/src/components/__snapshots__/Typography.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Typography.test.jsx.snap
@@ -17,7 +17,7 @@ exports[`<Typography> renders correct snapshot 1`] = `
     variant="body1"
   >
     <p
-      className="jsx-3017984631 root color-inherit initial body1 align-inherit transform-inherit riipen riipen-typography"
+      className="jsx-3132880061 root color-inherit initial body1 align-inherit transform-inherit riipen riipen-typography"
     />
     <JSXStyle
       dynamic={
@@ -79,6 +79,7 @@ exports[`<Typography> renders correct snapshot 1`] = `
           "#3caabb",
           "#4cc88d",
           "#e95353",
+          "#febb46",
           "#fff",
           700,
           300,
@@ -86,7 +87,7 @@ exports[`<Typography> renders correct snapshot 1`] = `
           400,
         ]
       }
-      id="3990007342"
+      id="1786047853"
     />
   </Typography>
 </withClasses(Typography)>


### PR DESCRIPTION
## Description
Add warning colour for Typography.

## Screenshots
![Screenshot_2021-04-01 Typography Riipen UI](https://user-images.githubusercontent.com/10818279/113359830-714a2d80-92fd-11eb-9d6e-3ad3adbcc67b.png)

## Where to Start
 packages/riipen-ui/src/components/Typography.jsx