### PR TITLE
Add Typography disabled colour

### DIFF
--- a/packages/riipen-ui-docs/src/pages/components/typography/Color.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/typography/Color.jsx
@@ -11,6 +11,9 @@ export default function Color() {
       <Typography color="black" gutter>
         Black
       </Typography>
+      <Typography color="disabled" gutter>
+        Disabled
+      </Typography>
       <Typography color="grey600" gutter>
         Grey 600
       </Typography>

--- a/packages/riipen-ui/package-lock.json
+++ b/packages/riipen-ui/package-lock.json
@@ -1,11 +1,11 @@
 {
 	"name": "riipen-ui",
-	"version": "0.4.9",
+	"version": "0.4.12",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"version": "0.4.9",
+			"version": "0.4.12",
 			"license": "MIT",
 			"devDependencies": {
 				"@babel/preset-env": "^7.10.4",

--- a/packages/riipen-ui/package.json
+++ b/packages/riipen-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riipen-ui",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "private": false,
   "author": {
     "name": "Riipen",

--- a/packages/riipen-ui/src/components/Typography.jsx
+++ b/packages/riipen-ui/src/components/Typography.jsx
@@ -40,6 +40,7 @@ class Typography extends React.Component {
       "inherit",
       "initial",
       "black",
+      "disabled",
       "grey600",
       "grey800",
       "greyA400",
@@ -256,6 +257,9 @@ class Typography extends React.Component {
           }
           .color-black {
             color: ${theme.palette.common.black};
+          }
+          .color-disabled {
+            color: ${theme.palette.text.disabled};
           }
           .color-grey600 {
             color: ${theme.palette.grey[600]};

--- a/packages/riipen-ui/src/components/__snapshots__/Breadcrumbs.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Breadcrumbs.test.jsx.snap
@@ -31,7 +31,7 @@ exports[`<Breadcrumbs> renders correct snapshot 1`] = `
         variant="body1"
       >
         <nav
-          className="jsx-3132880061 root color-inherit initial body1 align-inherit transform-inherit riipen riipen-typography"
+          className="jsx-42457783 root color-inherit initial body1 align-inherit transform-inherit riipen riipen-typography"
         >
           <ol
             className="jsx-2183045356 riipen riipen-breadcrumbs"
@@ -98,6 +98,7 @@ exports[`<Breadcrumbs> renders correct snapshot 1`] = `
               "23px",
               "0rem",
               "#000",
+              "#cccbcb",
               "#747474",
               "#424242",
               "#373737",
@@ -114,7 +115,7 @@ exports[`<Breadcrumbs> renders correct snapshot 1`] = `
               400,
             ]
           }
-          id="1786047853"
+          id="1840119567"
         />
       </Typography>
     </withClasses(Typography)>

--- a/packages/riipen-ui/src/components/__snapshots__/Checkbox.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Checkbox.test.jsx.snap
@@ -242,7 +242,7 @@ exports[`<Checkbox> renders correct snapshot 1`] = `
             variant="body1"
           >
             <p
-              className="jsx-3132880061 root color-inherit initial body1 align-inherit transform-inherit riipen riipen-typography"
+              className="jsx-42457783 root color-inherit initial body1 align-inherit transform-inherit riipen riipen-typography"
             />
             <JSXStyle
               dynamic={
@@ -296,6 +296,7 @@ exports[`<Checkbox> renders correct snapshot 1`] = `
                   "23px",
                   "0rem",
                   "#000",
+                  "#cccbcb",
                   "#747474",
                   "#424242",
                   "#373737",
@@ -312,7 +313,7 @@ exports[`<Checkbox> renders correct snapshot 1`] = `
                   400,
                 ]
               }
-              id="1786047853"
+              id="1840119567"
             />
           </Typography>
         </withClasses(Typography)>

--- a/packages/riipen-ui/src/components/__snapshots__/InputHint.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/InputHint.test.jsx.snap
@@ -32,7 +32,7 @@ exports[`<InputHint> renders correct snapshot 1`] = `
           variant="body2"
         >
           <p
-            className="jsx-3132880061 root color-inherit initial body2 align-inherit transform-inherit riipen riipen-typography"
+            className="jsx-42457783 root color-inherit initial body2 align-inherit transform-inherit riipen riipen-typography"
           />
           <JSXStyle
             dynamic={
@@ -86,6 +86,7 @@ exports[`<InputHint> renders correct snapshot 1`] = `
                 "23px",
                 "0rem",
                 "#000",
+                "#cccbcb",
                 "#747474",
                 "#424242",
                 "#373737",
@@ -102,7 +103,7 @@ exports[`<InputHint> renders correct snapshot 1`] = `
                 400,
               ]
             }
-            id="1786047853"
+            id="1840119567"
           />
         </Typography>
       </withClasses(Typography)>

--- a/packages/riipen-ui/src/components/__snapshots__/Radio.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Radio.test.jsx.snap
@@ -53,7 +53,7 @@ exports[`<Radio> renders correct snapshot 1`] = `
             variant="body1"
           >
             <p
-              className="jsx-3132880061 root color-inherit initial body1 align-inherit transform-inherit riipen riipen-typography jsx-835554889"
+              className="jsx-42457783 root color-inherit initial body1 align-inherit transform-inherit riipen riipen-typography jsx-835554889"
             >
               <JSXStyle
                 dynamic={
@@ -118,6 +118,7 @@ exports[`<Radio> renders correct snapshot 1`] = `
                   "23px",
                   "0rem",
                   "#000",
+                  "#cccbcb",
                   "#747474",
                   "#424242",
                   "#373737",
@@ -134,7 +135,7 @@ exports[`<Radio> renders correct snapshot 1`] = `
                   400,
                 ]
               }
-              id="1786047853"
+              id="1840119567"
             />
           </Typography>
         </withClasses(Typography)>

--- a/packages/riipen-ui/src/components/__snapshots__/RadioButton.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/RadioButton.test.jsx.snap
@@ -39,7 +39,7 @@ exports[`<RadioButton> renders correct snapshot 1`] = `
             variant="body2"
           >
             <p
-              className="jsx-3132880061 root color-grey600 initial body2 align-inherit transform-inherit riipen riipen-typography"
+              className="jsx-42457783 root color-grey600 initial body2 align-inherit transform-inherit riipen riipen-typography"
             >
               <span
                 className="jsx-1306841623 content"
@@ -97,6 +97,7 @@ exports[`<RadioButton> renders correct snapshot 1`] = `
                   "23px",
                   "0rem",
                   "#000",
+                  "#cccbcb",
                   "#747474",
                   "#424242",
                   "#373737",
@@ -113,7 +114,7 @@ exports[`<RadioButton> renders correct snapshot 1`] = `
                   400,
                 ]
               }
-              id="1786047853"
+              id="1840119567"
             />
           </Typography>
         </withClasses(Typography)>

--- a/packages/riipen-ui/src/components/__snapshots__/RadioButtonGroup.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/RadioButtonGroup.test.jsx.snap
@@ -67,7 +67,7 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
                     variant="body2"
                   >
                     <p
-                      className="jsx-3132880061 root color-grey600 initial body2 align-inherit transform-inherit riipen riipen-typography"
+                      className="jsx-42457783 root color-grey600 initial body2 align-inherit transform-inherit riipen riipen-typography"
                     >
                       <span
                         className="jsx-1306841623 content"
@@ -125,6 +125,7 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
                           "23px",
                           "0rem",
                           "#000",
+                          "#cccbcb",
                           "#747474",
                           "#424242",
                           "#373737",
@@ -141,7 +142,7 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
                           400,
                         ]
                       }
-                      id="1786047853"
+                      id="1840119567"
                     />
                   </Typography>
                 </withClasses(Typography)>

--- a/packages/riipen-ui/src/components/__snapshots__/Typography.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Typography.test.jsx.snap
@@ -17,7 +17,7 @@ exports[`<Typography> renders correct snapshot 1`] = `
     variant="body1"
   >
     <p
-      className="jsx-3132880061 root color-inherit initial body1 align-inherit transform-inherit riipen riipen-typography"
+      className="jsx-42457783 root color-inherit initial body1 align-inherit transform-inherit riipen riipen-typography"
     />
     <JSXStyle
       dynamic={
@@ -71,6 +71,7 @@ exports[`<Typography> renders correct snapshot 1`] = `
           "23px",
           "0rem",
           "#000",
+          "#cccbcb",
           "#747474",
           "#424242",
           "#373737",
@@ -87,7 +88,7 @@ exports[`<Typography> renders correct snapshot 1`] = `
           400,
         ]
       }
-      id="1786047853"
+      id="1840119567"
     />
   </Typography>
 </withClasses(Typography)>


### PR DESCRIPTION
## Description
Add 'disabled' color option to Typography.

## Screenshots
![Screenshot_2021-04-05 Typography Riipen UI](https://user-images.githubusercontent.com/10818279/113605413-7a881280-95fb-11eb-8919-3e1ec9ba5c9d.png)

## Where to Start
packages/riipen-ui/src/components/Typography.jsx
