### PR TITLE
[PLT-7203]: Add grey color to InputLabel

### DIFF
--- a/packages/riipen-ui/src/components/InputLabel.jsx
+++ b/packages/riipen-ui/src/components/InputLabel.jsx
@@ -26,7 +26,7 @@ class InputLabel extends React.Component {
     /**
      * Color of the label text
      */
-    color: PropTypes.oneOf(["default", "white", "black"]),
+    color: PropTypes.oneOf(["default", "white", "black", "grey"]),
 
     /**
      * Hint text to display under the label.
@@ -99,6 +99,10 @@ class InputLabel extends React.Component {
 
           .black {
             color: ${theme.palette.common.black};
+          }
+
+          .grey {
+            color: ${theme.palette.grey.A400};
           }
 
           .light {

--- a/packages/riipen-ui/src/components/__snapshots__/InputLabel.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/InputLabel.test.jsx.snap
@@ -23,12 +23,13 @@ exports[`<InputLabel> renders correct snapshot 1`] = `
           15,
           "#fff",
           "#000",
+          "#373737",
           300,
           500,
           700,
         ]
       }
-      id="2351364854"
+      id="190238727"
     />
   </InputLabel>
 </withClasses(InputLabel)>


### PR DESCRIPTION
## Description
New designs call for input labels to have #373737 color,
add grey as an option for our input labels.

## Notes

## Screenshots

## Where to Start
