### PR TITLE
Add Underlined and Default Input variants

### DIFF
--- a/packages/riipen-ui-docs/src/pages/components/input/Variant.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/input/Variant.jsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+import Form from "riipen-ui/components/Form";
+import Input from "riipen-ui/components/Input";
+
+export default function Variant() {
+  return (
+    <Form>
+      <Input id="name" label="Biography" variant="default" />
+      <div style={{ marginBottom: "10px" }} />
+      <Input id="name" label="Biography" variant="underlined" />
+    </Form>
+  );
+}

--- a/packages/riipen-ui-docs/src/pages/components/input/input.md
+++ b/packages/riipen-ui-docs/src/pages/components/input/input.md
@@ -29,20 +29,24 @@ The `labelColor` prop can change the color of the label.
 
 {{"demo": "pages/components/input/Color.js"}}
 
-
 ## Label Weight
 
 The `labelWeight` prop can change the weight of the label.
 
 {{"demo": "pages/components/input/Weight.js"}}
 
+## Variant
+
+The `variant` prop can change the styling of the input field.
+
+{{"demo": "pages/components/input/Variant.js"}}
+
 ## Accessibility
 
 In order for the input to be accessible, the input should be linked to the label. The underlying DOM nodes should have this structure.
 
 ```html
-<label for="my-input">Email address</label>
-<input id="my-input" />
+<label for="my-input">Email address</label> <input id="my-input" />
 ```
 
 If you are using the Input component, you just have to provide a unique `id` or `name`.

--- a/packages/riipen-ui/src/components/Input.jsx
+++ b/packages/riipen-ui/src/components/Input.jsx
@@ -74,12 +74,12 @@ const Input = ({
         {...other}
       />
       {error && (
-        <Typography color="negative" variant="body2">
+        <Typography color="negative" component="span" variant="body2">
           {error}
         </Typography>
       )}
       {warning && (
-        <Typography color="secondary" variant="body2">
+        <Typography color="secondary" component="span" variant="body2">
           {warning}
         </Typography>
       )}

--- a/packages/riipen-ui/src/components/Input.jsx
+++ b/packages/riipen-ui/src/components/Input.jsx
@@ -8,26 +8,25 @@ import { withThemeContext, useIsFocusVisible } from "../utils";
 import InputLabel from "./InputLabel";
 import Typography from "./Typography";
 
-const Input = props => {
-  const {
-    classes,
-    disabled,
-    error,
-    hint,
-    label,
-    labelColor,
-    labelWeight,
-    multiline,
-    required,
-    theme,
-    warning,
-    ...other
-  } = props;
-
+const Input = ({
+  classes,
+  disabled,
+  error,
+  hint,
+  label,
+  labelColor,
+  labelWeight,
+  multiline,
+  required,
+  theme,
+  variant,
+  warning,
+  ...other
+}) => {
   const [focusVisible, setFocusVisible] = useState(false);
   const { ref, isFocusVisible, onBlurVisible } = useIsFocusVisible();
 
-  const handleFocus = e => {
+  const handleFocus = (e) => {
     setFocusVisible(isFocusVisible(e));
   };
 
@@ -48,7 +47,8 @@ const Input = props => {
     error ? "error" : null,
     disabled ? "disabled" : null,
     warning ? "warning" : null,
-    focusVisible ? "focusVisible" : null
+    focusVisible ? "focusVisible" : null,
+    variant
   );
 
   return (
@@ -86,9 +86,6 @@ const Input = props => {
       <style jsx>{`
         input,
         textarea {
-          background-color: ${theme.palette.common.white};
-          border: 1px solid rgba(0, 0, 0, 0.23);
-          border-radius: ${theme.shape.borderRadius.md};
           box-sizing: border-box;
           color: ${theme.palette.text.primary};
           font-family: ${theme.typography.fontFamily};
@@ -112,6 +109,12 @@ const Input = props => {
           outline: 5px auto -webkit-focus-ring-color;
         }
 
+        .default {
+          background-color: ${theme.palette.common.white};
+          border: 1px solid rgba(0, 0, 0, 0.23);
+          border-radius: ${theme.shape.borderRadius.md};
+        }
+
         .disabled {
           opacity: 0.5;
           pointer-events: none;
@@ -119,6 +122,12 @@ const Input = props => {
 
         .error {
           border-color: ${theme.palette.negative.main};
+        }
+
+        .underlined {
+          background-color: transparent;
+          border: none;
+          border-bottom: 1px solid rgba(0, 0, 0, 0.23);
         }
 
         .warning {
@@ -131,7 +140,8 @@ const Input = props => {
 
 Input.defaultProps = {
   disabled: false,
-  multiline: false
+  multiline: false,
+  variant: "default"
 };
 
 Input.propTypes = {
@@ -186,6 +196,10 @@ Input.propTypes = {
    */
   theme: PropTypes.object,
 
+  /**
+   * The input variant styling to apply.
+   */
+  variant: PropTypes.oneOf(["default", "underlined"]),
   /**
    * A warning to display below the input.
    */

--- a/packages/riipen-ui/src/components/Input.test.jsx
+++ b/packages/riipen-ui/src/components/Input.test.jsx
@@ -220,6 +220,14 @@ describe("<Input>", () => {
     });
   });
 
+  describe("variant prop", () => {
+    it("sets valid variant", () => {
+      const wrapper = mount(<Input variant="underlined" />);
+
+      expect(wrapper.find("input").hasClass("underlined")).toEqual(true);
+    });
+  });
+
   describe("warning prop", () => {
     it("sets valid custom warning", () => {
       const warning = <span>Error</span>;

--- a/packages/riipen-ui/src/components/__snapshots__/Input.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Input.test.jsx.snap
@@ -215,13 +215,14 @@ exports[`<Input> renders correct snapshot 1`] = `
         },
       }
     }
+    variant="default"
   >
     <div
-      className="jsx-2918390004 "
+      className="jsx-3113390966 "
     >
       <input
         aria-disabled={false}
-        className="jsx-2918390004 "
+        className="jsx-3113390966 default"
         disabled={false}
         onBlur={[Function]}
         onFocus={[Function]}
@@ -229,19 +230,19 @@ exports[`<Input> renders correct snapshot 1`] = `
       <JSXStyle
         dynamic={
           Array [
-            "#fff",
-            "4px",
             "#373737",
             "Roboto, Helvetica, Arial, sans-serif",
             "14px",
             10,
             300,
             "#3caabb",
+            "#fff",
+            "4px",
             "#e95353",
             "#febb46",
           ]
         }
-        id="4179543332"
+        id="1265023844"
       />
     </div>
   </Input>


### PR DESCRIPTION
## Description
Add new `variant` prop that styles the Input component.
The `default` variant is the current styling.  The `underlined` variant displays only an underline.
Update tests and snapshots.

## Screenshots
![Screenshot_2021-04-06 Input Riipen UI](https://user-images.githubusercontent.com/10818279/113770412-f3a86800-96d6-11eb-85f2-b37f2826a285.png)

## Where to Start
 packages/riipen-ui/src/components/Input.jsx 