### PR TITLE
Add Input size prop

### DIFF
--- a/packages/riipen-ui-docs/src/pages/components/input/Icon.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/input/Icon.jsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faQuidditch } from "@fortawesome/free-solid-svg-icons";
+
+import Form from "riipen-ui/components/Form";
+import Input from "riipen-ui/components/Input";
+
+export default function Icon() {
+  const style = { marginBottom: "10px" };
+
+  return (
+    <Form>
+      <Input
+        id="name"
+        label="Sports"
+        icon={<FontAwesomeIcon icon={faQuidditch} />}
+        size="small"
+      />
+      <div style={style} />
+      <Input
+        id="name"
+        label="Sports"
+        icon={<FontAwesomeIcon icon={faQuidditch} />}
+        size="medium"
+      />
+      <div style={style} />
+      <Input
+        id="name"
+        label="Sports"
+        icon={<FontAwesomeIcon icon={faQuidditch} />}
+        size="large"
+      />
+    </Form>
+  );
+}

--- a/packages/riipen-ui-docs/src/pages/components/input/Size.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/input/Size.jsx
@@ -7,7 +7,7 @@ export default function Size() {
   const style = { marginBottom: "10px" };
   return (
     <Form>
-      <Input id="name" label="Small" value="Anchovy" size="small" />
+      <Input id="name" label="Small" value="Sardine" size="small" />
       <div style={style} />
       <Input id="name" label="Medium" value="Cat" size="medium" />
       <div style={style} />

--- a/packages/riipen-ui-docs/src/pages/components/input/Size.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/input/Size.jsx
@@ -7,11 +7,11 @@ export default function Size() {
   const style = { marginBottom: "10px" };
   return (
     <Form>
-      <Input id="name" label="Animal" value="Anchovy" size="small" />
+      <Input id="name" label="Small" value="Anchovy" size="small" />
       <div style={style} />
-      <Input id="name" label="Animal" value="Cat" size="medium" />
+      <Input id="name" label="Medium" value="Cat" size="medium" />
       <div style={style} />
-      <Input id="name" label="Animal" value="Elephant" size="large" />
+      <Input id="name" label="Large" value="Elephant" size="large" />
     </Form>
   );
 }

--- a/packages/riipen-ui-docs/src/pages/components/input/Size.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/input/Size.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+import Form from "riipen-ui/components/Form";
+import Input from "riipen-ui/components/Input";
+
+export default function Size() {
+  const style = { marginBottom: "10px" };
+  return (
+    <Form>
+      <Input id="name" label="Animal" value="Anchovy" size="small" />
+      <div style={style} />
+      <Input id="name" label="Animal" value="Cat" size="medium" />
+      <div style={style} />
+      <Input id="name" label="Animal" value="Elephant" size="large" />
+    </Form>
+  );
+}

--- a/packages/riipen-ui-docs/src/pages/components/input/Variant.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/input/Variant.jsx
@@ -6,9 +6,9 @@ import Input from "riipen-ui/components/Input";
 export default function Variant() {
   return (
     <Form>
-      <Input id="name" label="Biography" variant="default" />
+      <Input id="name" label="Default" variant="default" />
       <div style={{ marginBottom: "10px" }} />
-      <Input id="name" label="Biography" variant="underlined" />
+      <Input id="name" label="Underlined" variant="underlined" />
     </Form>
   );
 }

--- a/packages/riipen-ui-docs/src/pages/components/input/input.md
+++ b/packages/riipen-ui-docs/src/pages/components/input/input.md
@@ -23,6 +23,12 @@ The `multiline` prop transforms the input into a `textarea`.
 
 {{"demo": "pages/components/input/Multiline.js"}}
 
+## Icon
+
+An `icon` can be added to the left side of the input.
+
+{{"demo": "pages/components/input/Icon.js"}}
+
 ## Label Color
 
 The `labelColor` prop can change the color of the label.

--- a/packages/riipen-ui-docs/src/pages/components/input/input.md
+++ b/packages/riipen-ui-docs/src/pages/components/input/input.md
@@ -35,6 +35,12 @@ The `labelWeight` prop can change the weight of the label.
 
 {{"demo": "pages/components/input/Weight.js"}}
 
+## Size
+
+The `size` prop changes the size of the input field.
+
+{{"demo": "pages/components/input/Size.js"}}
+
 ## Variant
 
 The `variant` prop can change the styling of the input field.

--- a/packages/riipen-ui/src/components/Input.jsx
+++ b/packages/riipen-ui/src/components/Input.jsx
@@ -18,6 +18,7 @@ const Input = ({
   labelWeight,
   multiline,
   required,
+  size,
   theme,
   variant,
   warning,
@@ -48,7 +49,8 @@ const Input = ({
     disabled ? "disabled" : null,
     warning ? "warning" : null,
     focusVisible ? "focusVisible" : null,
-    variant
+    variant,
+    size
   );
 
   return (
@@ -92,7 +94,6 @@ const Input = ({
           font-size: ${theme.typography.body1.fontSize};
           line-height: 1;
           outline: none;
-          padding: ${theme.spacing(2)}px;
           position: relative;
           transition: all ${theme.transitions.duration.standard}ms;
           width: 100%;
@@ -133,6 +134,18 @@ const Input = ({
         .warning {
           border-color: ${theme.palette.warning.main};
         }
+
+        .small {
+          padding: ${theme.spacing(1)}px;
+        }
+
+        .medium {
+          padding: ${theme.spacing(2)}px;
+        }
+
+        .large {
+          padding: ${theme.spacing(4)}px;
+        }
       `}</style>
     </div>
   );
@@ -141,6 +154,7 @@ const Input = ({
 Input.defaultProps = {
   disabled: false,
   multiline: false,
+  size: "medium",
   variant: "default"
 };
 
@@ -189,6 +203,11 @@ Input.propTypes = {
    * If true, an asterisk will be appended to the end of the label.
    */
   required: PropTypes.bool,
+
+  /**
+   * A whitelisted set of sizes that the input can be rendered at.
+   */
+  size: PropTypes.oneOf(["large", "medium", "small"]),
 
   /**
    * @ignore

--- a/packages/riipen-ui/src/components/Input.jsx
+++ b/packages/riipen-ui/src/components/Input.jsx
@@ -136,7 +136,7 @@ const Input = ({
         }
 
         .small {
-          padding: ${theme.spacing(1)}px;
+          padding: ${theme.spacing(1)}px ${theme.spacing(2)}px;
         }
 
         .medium {
@@ -144,7 +144,8 @@ const Input = ({
         }
 
         .large {
-          padding: ${theme.spacing(4)}px;
+          font-size: ${theme.typography.h2.fontSize};
+          padding: ${theme.spacing(2)}px;
         }
       `}</style>
     </div>

--- a/packages/riipen-ui/src/components/Input.jsx
+++ b/packages/riipen-ui/src/components/Input.jsx
@@ -13,6 +13,7 @@ const Input = ({
   disabled,
   error,
   hint,
+  icon: Icon,
   label,
   labelColor,
   labelWeight,
@@ -47,6 +48,7 @@ const Input = ({
   const componentClassName = clsx(
     error ? "error" : null,
     disabled ? "disabled" : null,
+    Icon ? "iconPadding" : null,
     warning ? "warning" : null,
     focusVisible ? "focusVisible" : null,
     variant,
@@ -75,6 +77,11 @@ const Input = ({
         aria-disabled={disabled}
         {...other}
       />
+      {Icon && (
+        <span className={clsx("icon", size)}>
+          {typeof Icon === "function" ? <Icon /> : Icon}
+        </span>
+      )}
       {error && (
         <Typography color="negative" component="span" variant="body2">
           {error}
@@ -126,14 +133,36 @@ const Input = ({
           border-color: ${theme.palette.negative.main};
         }
 
-        .underlined {
-          background-color: transparent;
-          border: none;
-          border-bottom: 1px solid rgba(0, 0, 0, 0.23);
+        .icon {
+          color: ${theme.palette.grey[500]};
+          left: ${theme.spacing(4)}px;
+          position: absolute;
         }
 
-        .warning {
-          border-color: ${theme.palette.warning.main};
+        .icon.small {
+          font-size: ${theme.typography.body2.fontSize};
+          padding: 7px;
+        }
+
+        .icon.medium {
+          font-size: ${theme.typography.h5.fontSize};
+        }
+
+        .icon.large {
+          font-size: ${theme.typography.h4.fontSize};
+          padding: 17px;
+        }
+
+        .iconPadding.small {
+          padding-left: ${theme.spacing(9)}px;
+        }
+
+        .iconPadding.medium {
+          padding-left: ${theme.spacing(9)}px;
+        }
+
+        .iconPadding.large {
+          padding-left: ${theme.spacing(12)}px;
         }
 
         .small {
@@ -143,6 +172,16 @@ const Input = ({
 
         .large {
           font-size: ${theme.typography.h2.fontSize};
+        }
+
+        .underlined {
+          background-color: transparent;
+          border: none;
+          border-bottom: 1px solid rgba(0, 0, 0, 0.23);
+        }
+
+        .warning {
+          border-color: ${theme.palette.warning.main};
         }
       `}</style>
     </div>
@@ -176,6 +215,11 @@ Input.propTypes = {
    * Hint text to display under the label of the input.
    */
   hint: PropTypes.string,
+
+  /**
+   * A icon to render on the left side of the input.
+   */
+  icon: PropTypes.oneOfType([PropTypes.elementType, PropTypes.node]),
 
   /**
    * Label text to display for the input.

--- a/packages/riipen-ui/src/components/Input.jsx
+++ b/packages/riipen-ui/src/components/Input.jsx
@@ -94,6 +94,7 @@ const Input = ({
           font-size: ${theme.typography.body1.fontSize};
           line-height: 1;
           outline: none;
+          padding: ${theme.spacing(2)}px;
           position: relative;
           transition: all ${theme.transitions.duration.standard}ms;
           width: 100%;
@@ -136,16 +137,12 @@ const Input = ({
         }
 
         .small {
-          padding: ${theme.spacing(1)}px ${theme.spacing(2)}px;
-        }
-
-        .medium {
-          padding: ${theme.spacing(2)}px;
+          padding-bottom: ${theme.spacing(1)}px;
+          padding-top: ${theme.spacing(1)}px;
         }
 
         .large {
           font-size: ${theme.typography.h2.fontSize};
-          padding: ${theme.spacing(2)}px;
         }
       `}</style>
     </div>

--- a/packages/riipen-ui/src/components/Input.test.jsx
+++ b/packages/riipen-ui/src/components/Input.test.jsx
@@ -2,6 +2,9 @@ import { mount } from "enzyme";
 import toJson from "enzyme-to-json";
 import React from "react";
 
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faTrash } from "@fortawesome/free-solid-svg-icons";
+
 import Input from "./Input";
 
 describe("<Input>", () => {
@@ -130,6 +133,43 @@ describe("<Input>", () => {
     });
   });
 
+  describe("icon prop", () => {
+    it("renders icon with a component icon", () => {
+      const iconFn = (i) => (props) => <FontAwesomeIcon icon={i} {...props} />;
+      const icon = iconFn(faTrash);
+
+      const wrapper = mount(<Input icon={icon} />);
+
+      expect(
+        wrapper
+          .find(".icon")
+          .childAt(0)
+          .childAt(0)
+          .name()
+      ).toEqual("FontAwesomeIcon");
+    });
+
+    it("renders icon with a jsx icon", () => {
+      const wrapper = mount(
+        <Input icon={<FontAwesomeIcon icon={faTrash} />} />
+      );
+
+      expect(
+        wrapper
+          .find(".icon")
+          .childAt(0)
+          .name()
+      ).toEqual("FontAwesomeIcon");
+    });
+
+    it("sets correct input classes", () => {
+      const icon = "flex";
+
+      const wrapper = mount(<Input icon={icon} />);
+
+      expect(wrapper.find("input").hasClass("iconPadding")).toEqual(true);
+    });
+  });
   describe("label prop", () => {
     it("sets valid custom label", () => {
       const label = "Test";

--- a/packages/riipen-ui/src/components/Input.test.jsx
+++ b/packages/riipen-ui/src/components/Input.test.jsx
@@ -220,6 +220,14 @@ describe("<Input>", () => {
     });
   });
 
+  describe("size prop", () => {
+    it("sets valid size", () => {
+      const wrapper = mount(<Input size="small" />);
+
+      expect(wrapper.find("input").hasClass("small")).toEqual(true);
+    });
+  });
+
   describe("variant prop", () => {
     it("sets valid variant", () => {
       const wrapper = mount(<Input variant="underlined" />);

--- a/packages/riipen-ui/src/components/__snapshots__/Input.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Input.test.jsx.snap
@@ -5,6 +5,7 @@ exports[`<Input> renders correct snapshot 1`] = `
   <Input
     disabled={false}
     multiline={false}
+    size="medium"
     theme={
       Object {
         "breakpoints": Object {
@@ -218,11 +219,11 @@ exports[`<Input> renders correct snapshot 1`] = `
     variant="default"
   >
     <div
-      className="jsx-3113390966 "
+      className="jsx-2064073676 "
     >
       <input
         aria-disabled={false}
-        className="jsx-3113390966 default"
+        className="jsx-2064073676 default medium"
         disabled={false}
         onBlur={[Function]}
         onFocus={[Function]}
@@ -233,16 +234,18 @@ exports[`<Input> renders correct snapshot 1`] = `
             "#373737",
             "Roboto, Helvetica, Arial, sans-serif",
             "14px",
-            10,
             300,
             "#3caabb",
             "#fff",
             "4px",
             "#e95353",
             "#febb46",
+            5,
+            10,
+            20,
           ]
         }
-        id="1265023844"
+        id="1573840811"
       />
     </div>
   </Input>

--- a/packages/riipen-ui/src/components/__snapshots__/Input.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Input.test.jsx.snap
@@ -219,11 +219,11 @@ exports[`<Input> renders correct snapshot 1`] = `
     variant="default"
   >
     <div
-      className="jsx-2064073676 "
+      className="jsx-956543153 "
     >
       <input
         aria-disabled={false}
-        className="jsx-2064073676 default medium"
+        className="jsx-956543153 default medium"
         disabled={false}
         onBlur={[Function]}
         onFocus={[Function]}
@@ -234,6 +234,7 @@ exports[`<Input> renders correct snapshot 1`] = `
             "#373737",
             "Roboto, Helvetica, Arial, sans-serif",
             "14px",
+            10,
             300,
             "#3caabb",
             "#fff",
@@ -241,11 +242,11 @@ exports[`<Input> renders correct snapshot 1`] = `
             "#e95353",
             "#febb46",
             5,
-            10,
-            20,
+            5,
+            "30px",
           ]
         }
-        id="1573840811"
+        id="3977161612"
       />
     </div>
   </Input>

--- a/packages/riipen-ui/src/components/__snapshots__/Input.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Input.test.jsx.snap
@@ -219,11 +219,11 @@ exports[`<Input> renders correct snapshot 1`] = `
     variant="default"
   >
     <div
-      className="jsx-956543153 "
+      className="jsx-2098638671 "
     >
       <input
         aria-disabled={false}
-        className="jsx-956543153 default medium"
+        className="jsx-2098638671 default medium"
         disabled={false}
         onBlur={[Function]}
         onFocus={[Function]}
@@ -240,13 +240,21 @@ exports[`<Input> renders correct snapshot 1`] = `
             "#fff",
             "4px",
             "#e95353",
-            "#febb46",
+            "#9a9a9a",
+            20,
+            "12px",
+            "16px",
+            "20px",
+            45,
+            45,
+            60,
             5,
             5,
             "30px",
+            "#febb46",
           ]
         }
-        id="3977161612"
+        id="1259296040"
       />
     </div>
   </Input>


### PR DESCRIPTION
## Description
Add `size` prop to Input component.  This prop changes the padding inside the input.
Update tests and docs.

## Screenshots
![Screenshot_2021-04-07 Input Riipen UI(2)](https://user-images.githubusercontent.com/10818279/113908703-b0f49780-978b-11eb-97cb-22ad6ae378e6.png)


## Where to Start
packages/riipen-ui/src/components/Input.jsx 
