### PR TITLE
Add icon prop to Input

### DIFF
--- a/packages/riipen-ui-docs/src/pages/components/input/Icon.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/input/Icon.jsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faQuidditch } from "@fortawesome/free-solid-svg-icons";
+
+import Form from "riipen-ui/components/Form";
+import Input from "riipen-ui/components/Input";
+
+export default function Icon() {
+  const style = { marginBottom: "10px" };
+
+  return (
+    <Form>
+      <Input
+        id="name"
+        label="Sports"
+        icon={<FontAwesomeIcon icon={faQuidditch} />}
+        size="small"
+      />
+      <div style={style} />
+      <Input
+        id="name"
+        label="Sports"
+        icon={<FontAwesomeIcon icon={faQuidditch} />}
+        size="medium"
+      />
+      <div style={style} />
+      <Input
+        id="name"
+        label="Sports"
+        icon={<FontAwesomeIcon icon={faQuidditch} />}
+        size="large"
+      />
+    </Form>
+  );
+}

--- a/packages/riipen-ui-docs/src/pages/components/input/input.md
+++ b/packages/riipen-ui-docs/src/pages/components/input/input.md
@@ -23,6 +23,12 @@ The `multiline` prop transforms the input into a `textarea`.
 
 {{"demo": "pages/components/input/Multiline.js"}}
 
+## Icon
+
+An `icon` can be added to the left side of the input.
+
+{{"demo": "pages/components/input/Icon.js"}}
+
 ## Label Color
 
 The `labelColor` prop can change the color of the label.

--- a/packages/riipen-ui/src/components/Input.jsx
+++ b/packages/riipen-ui/src/components/Input.jsx
@@ -48,7 +48,7 @@ const Input = ({
   const componentClassName = clsx(
     error ? "error" : null,
     disabled ? "disabled" : null,
-    Icon ? "iconInput" : null,
+    Icon ? "iconPadding" : null,
     warning ? "warning" : null,
     focusVisible ? "focusVisible" : null,
     variant,
@@ -153,15 +153,15 @@ const Input = ({
           padding: 17px;
         }
 
-        .iconInput.small {
+        .iconPadding.small {
           padding-left: ${theme.spacing(9)}px;
         }
 
-        .iconInput.medium {
+        .iconPadding.medium {
           padding-left: ${theme.spacing(9)}px;
         }
 
-        .iconInput.large {
+        .iconPadding.large {
           padding-left: ${theme.spacing(12)}px;
         }
 

--- a/packages/riipen-ui/src/components/Input.jsx
+++ b/packages/riipen-ui/src/components/Input.jsx
@@ -13,6 +13,7 @@ const Input = ({
   disabled,
   error,
   hint,
+  icon: Icon,
   label,
   labelColor,
   labelWeight,
@@ -47,6 +48,7 @@ const Input = ({
   const componentClassName = clsx(
     error ? "error" : null,
     disabled ? "disabled" : null,
+    Icon ? "iconInput" : null,
     warning ? "warning" : null,
     focusVisible ? "focusVisible" : null,
     variant,
@@ -75,6 +77,11 @@ const Input = ({
         aria-disabled={disabled}
         {...other}
       />
+      {Icon && (
+        <span className={clsx("icon", size)}>
+          {typeof Icon === "function" ? <Icon /> : Icon}
+        </span>
+      )}
       {error && (
         <Typography color="negative" component="span" variant="body2">
           {error}
@@ -126,14 +133,36 @@ const Input = ({
           border-color: ${theme.palette.negative.main};
         }
 
-        .underlined {
-          background-color: transparent;
-          border: none;
-          border-bottom: 1px solid rgba(0, 0, 0, 0.23);
+        .icon {
+          color: ${theme.palette.grey[500]};
+          left: ${theme.spacing(4)}px;
+          position: absolute;
         }
 
-        .warning {
-          border-color: ${theme.palette.warning.main};
+        .icon.small {
+          font-size: ${theme.typography.body2.fontSize};
+          padding: 7px;
+        }
+
+        .icon.medium {
+          font-size: ${theme.typography.h5.fontSize};
+        }
+
+        .icon.large {
+          font-size: ${theme.typography.h4.fontSize};
+          padding: 17px;
+        }
+
+        .iconInput.small {
+          padding-left: ${theme.spacing(9)}px;
+        }
+
+        .iconInput.medium {
+          padding-left: ${theme.spacing(9)}px;
+        }
+
+        .iconInput.large {
+          padding-left: ${theme.spacing(12)}px;
         }
 
         .small {
@@ -143,6 +172,16 @@ const Input = ({
 
         .large {
           font-size: ${theme.typography.h2.fontSize};
+        }
+
+        .underlined {
+          background-color: transparent;
+          border: none;
+          border-bottom: 1px solid rgba(0, 0, 0, 0.23);
+        }
+
+        .warning {
+          border-color: ${theme.palette.warning.main};
         }
       `}</style>
     </div>
@@ -176,6 +215,11 @@ Input.propTypes = {
    * Hint text to display under the label of the input.
    */
   hint: PropTypes.string,
+
+  /**
+   * A icon to render on the left side of the input.
+   */
+  icon: PropTypes.oneOfType([PropTypes.elementType, PropTypes.node]),
 
   /**
    * Label text to display for the input.

--- a/packages/riipen-ui/src/components/Input.test.jsx
+++ b/packages/riipen-ui/src/components/Input.test.jsx
@@ -167,7 +167,7 @@ describe("<Input>", () => {
 
       const wrapper = mount(<Input icon={icon} />);
 
-      expect(wrapper.find("input").hasClass("iconInput")).toEqual(true);
+      expect(wrapper.find("input").hasClass("iconPadding")).toEqual(true);
     });
   });
   describe("label prop", () => {

--- a/packages/riipen-ui/src/components/Input.test.jsx
+++ b/packages/riipen-ui/src/components/Input.test.jsx
@@ -2,6 +2,9 @@ import { mount } from "enzyme";
 import toJson from "enzyme-to-json";
 import React from "react";
 
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faTrash } from "@fortawesome/free-solid-svg-icons";
+
 import Input from "./Input";
 
 describe("<Input>", () => {
@@ -130,6 +133,43 @@ describe("<Input>", () => {
     });
   });
 
+  describe("icon prop", () => {
+    it("renders icon with a component icon", () => {
+      const iconFn = (i) => (props) => <FontAwesomeIcon icon={i} {...props} />;
+      const icon = iconFn(faTrash);
+
+      const wrapper = mount(<Input icon={icon} />);
+
+      expect(
+        wrapper
+          .find(".icon")
+          .childAt(0)
+          .childAt(0)
+          .name()
+      ).toEqual("FontAwesomeIcon");
+    });
+
+    it("renders icon with a jsx icon", () => {
+      const wrapper = mount(
+        <Input icon={<FontAwesomeIcon icon={faTrash} />} />
+      );
+
+      expect(
+        wrapper
+          .find(".icon")
+          .childAt(0)
+          .name()
+      ).toEqual("FontAwesomeIcon");
+    });
+
+    it("sets correct input classes", () => {
+      const icon = "flex";
+
+      const wrapper = mount(<Input icon={icon} />);
+
+      expect(wrapper.find("input").hasClass("iconInput")).toEqual(true);
+    });
+  });
   describe("label prop", () => {
     it("sets valid custom label", () => {
       const label = "Test";

--- a/packages/riipen-ui/src/components/__snapshots__/Input.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Input.test.jsx.snap
@@ -219,11 +219,11 @@ exports[`<Input> renders correct snapshot 1`] = `
     variant="default"
   >
     <div
-      className="jsx-2909188789 "
+      className="jsx-2098638671 "
     >
       <input
         aria-disabled={false}
-        className="jsx-2909188789 default medium"
+        className="jsx-2098638671 default medium"
         disabled={false}
         onBlur={[Function]}
         onFocus={[Function]}
@@ -254,7 +254,7 @@ exports[`<Input> renders correct snapshot 1`] = `
             "#febb46",
           ]
         }
-        id="853995106"
+        id="1259296040"
       />
     </div>
   </Input>

--- a/packages/riipen-ui/src/components/__snapshots__/Input.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Input.test.jsx.snap
@@ -219,11 +219,11 @@ exports[`<Input> renders correct snapshot 1`] = `
     variant="default"
   >
     <div
-      className="jsx-956543153 "
+      className="jsx-2909188789 "
     >
       <input
         aria-disabled={false}
-        className="jsx-956543153 default medium"
+        className="jsx-2909188789 default medium"
         disabled={false}
         onBlur={[Function]}
         onFocus={[Function]}
@@ -240,13 +240,21 @@ exports[`<Input> renders correct snapshot 1`] = `
             "#fff",
             "4px",
             "#e95353",
-            "#febb46",
+            "#9a9a9a",
+            20,
+            "12px",
+            "16px",
+            "20px",
+            45,
+            45,
+            60,
             5,
             5,
             "30px",
+            "#febb46",
           ]
         }
-        id="3977161612"
+        id="853995106"
       />
     </div>
   </Input>


### PR DESCRIPTION
## Description
Add icon prop to Input component. This renders an icon on the left side of the input.  Also update icon sizes based on `size` prop.
Update docs and tests.

## Notes
Open to adding support for flexibility of icons on either right or left side.
Based off https://github.com/riipen/ui/pull/187.

## Screenshots
![Screenshot_2021-04-06 Input Riipen UI(3)](https://user-images.githubusercontent.com/10818279/113795912-cd002680-9702-11eb-94e9-8a2cd9d4b442.png)

## Where to Start
packages/riipen-ui/src/components/Input.jsx 
