### PR TITLE
Add meta prop to Input component

### DIFF
--- a/packages/riipen-ui-docs/src/pages/components/input/Meta.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/input/Meta.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+import Form from "riipen-ui/components/Form";
+import Input from "riipen-ui/components/Input";
+
+export default function Meta() {
+  return (
+    <Form>
+      <Input id="default" label="Meta" meta="Character Count" />
+      <div style={{ marginBottom: "10px" }} />
+      <Input
+        id="default"
+        label="Meta"
+        meta="Character Count"
+        error="This is an error!"
+      />
+    </Form>
+  );
+}

--- a/packages/riipen-ui-docs/src/pages/components/input/input.md
+++ b/packages/riipen-ui-docs/src/pages/components/input/input.md
@@ -17,6 +17,12 @@ The `error` prop toggles the error state.
 
 {{"demo": "pages/components/input/Validation.js"}}
 
+## Meta
+
+The `meta` prop displays additional text in the bottom right.
+
+{{"demo": "pages/components/input/Meta.js"}}
+
 ## Multiline
 
 The `multiline` prop transforms the input into a `textarea`.

--- a/packages/riipen-ui/src/components/Input.jsx
+++ b/packages/riipen-ui/src/components/Input.jsx
@@ -17,6 +17,7 @@ const Input = ({
   label,
   labelColor,
   labelWeight,
+  meta,
   multiline,
   required,
   size,
@@ -82,17 +83,33 @@ const Input = ({
           {typeof Icon === "function" ? <Icon /> : Icon}
         </span>
       )}
-      {error && (
-        <Typography color="negative" component="span" variant="body2">
-          {error}
-        </Typography>
-      )}
-      {warning && (
-        <Typography color="secondary" component="span" variant="body2">
-          {warning}
-        </Typography>
+      {(error || warning || meta) && (
+        <div className="bottom">
+          <div>
+            {error && (
+              <Typography color="negative" component="div" variant="body2">
+                {error}
+              </Typography>
+            )}
+            {warning && (
+              <Typography color="secondary" component="div" variant="body2">
+                {warning}
+              </Typography>
+            )}
+          </div>
+          {meta && (
+            <Typography color="grey600" component="span" variant="body2">
+              {meta}
+            </Typography>
+          )}
+        </div>
       )}
       <style jsx>{`
+        .bottom {
+          display: flex;
+          justify-content: space-between;
+        }
+
         input,
         textarea {
           box-sizing: border-box;
@@ -170,6 +187,10 @@ const Input = ({
           padding-top: ${theme.spacing(1)}px;
         }
 
+        .medium {
+          padding: ${theme.spacing(2)}px;
+        }
+
         .large {
           font-size: ${theme.typography.h2.fontSize};
         }
@@ -235,6 +256,11 @@ Input.propTypes = {
    * Label text weight.
    */
   labelWeight: PropTypes.string,
+
+  /**
+   * Any text to display under the right side of the input.
+   */
+  meta: PropTypes.node,
 
   /**
    * If `true`, a textarea element will be rendered.

--- a/packages/riipen-ui/src/components/Input.test.jsx
+++ b/packages/riipen-ui/src/components/Input.test.jsx
@@ -221,6 +221,16 @@ describe("<Input>", () => {
     });
   });
 
+  describe("meta prop", () => {
+    it("renders meta", () => {
+      const meta = <span>Meta</span>;
+
+      const wrapper = mount(<Input meta={meta} />);
+
+      expect(wrapper.find("Typography").contains(meta)).toEqual(true);
+    });
+  });
+
   describe("multiline prop", () => {
     it("sets component as textarea with true multiline prop", () => {
       const multiline = true;

--- a/packages/riipen-ui/src/components/__snapshots__/Input.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Input.test.jsx.snap
@@ -219,11 +219,11 @@ exports[`<Input> renders correct snapshot 1`] = `
     variant="default"
   >
     <div
-      className="jsx-2098638671 "
+      className="jsx-2450181796 "
     >
       <input
         aria-disabled={false}
-        className="jsx-2098638671 default medium"
+        className="jsx-2450181796 default medium"
         disabled={false}
         onBlur={[Function]}
         onFocus={[Function]}
@@ -250,11 +250,12 @@ exports[`<Input> renders correct snapshot 1`] = `
             60,
             5,
             5,
+            10,
             "30px",
             "#febb46",
           ]
         }
-        id="1259296040"
+        id="4050115136"
       />
     </div>
   </Input>


### PR DESCRIPTION
## Description
Add `meta` prop to Input. This displays things on the bottom right of the Input field.
Update some logic with rendering error/warning, so that it works nicely with meta.
Update tests/docs.

## Screenshots
![Screenshot_2021-04-07 Input Riipen UI(4)](https://user-images.githubusercontent.com/10818279/113919626-aa205180-9798-11eb-9e3a-f06740e686eb.png)

## Where to Start
 packages/riipen-ui/src/components/Input.jsx
