### PR TITLE
[PLT-7434] Add justify-content: flex-end to Badge .root

### DIFF
--- a/packages/riipen-ui/src/components/Badge.jsx
+++ b/packages/riipen-ui/src/components/Badge.jsx
@@ -142,6 +142,7 @@ class Badge extends React.Component {
           .root {
             display: inline-flex;
             flex-shrink: 0;
+            justify-content: flex-end;
             position: relative;
             vertical-align: middle;
           }

--- a/packages/riipen-ui/src/components/__snapshots__/Badge.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Badge.test.jsx.snap
@@ -24,10 +24,10 @@ exports[`<Badge> renders correct snapshot 1`] = `
     variant="standard"
   >
     <span
-      className="jsx-1015140608 root"
+      className="jsx-2728802926 root"
     >
       <span
-        className="jsx-1015140608 badge hidden top-right-rectangle primary standard medium riipen riipen-badge"
+        className="jsx-2728802926 badge hidden top-right-rectangle primary standard medium riipen riipen-badge"
       />
     </span>
     <JSXStyle
@@ -56,7 +56,7 @@ exports[`<Badge> renders correct snapshot 1`] = `
           "#fff",
         ]
       }
-      id="2138813230"
+      id="4120284361"
     />
   </Badge>
 </withClasses(Badge)>


### PR DESCRIPTION

## Description
Adding justify-content: flex-end allows us to use badge
around an avatar that is part of a Grid
(such as for platform-web/Layout/Wizard/Steps/Icon). Adding this property
does not appear to adversely affect other Badges on the platform.
(Tested with NavbarMessages badge).

## Notes

## Screenshots
Before
![Screen Shot 2021-04-29 at 2 42 23 PM](https://user-images.githubusercontent.com/36321777/116602218-6c2acf00-a8f9-11eb-993f-e5c62de3edec.png)

After
![Screen Shot 2021-04-29 at 2 41 39 PM](https://user-images.githubusercontent.com/36321777/116602219-6cc36580-a8f9-11eb-8dee-236f95a48c7f.png)

## Where to Start
