### PR TITLE
Add EditorUtils various util functions for editor manipulation

### DIFF
--- a/packages/riipen-ui-docs/src/pages/components/rich-text-editor/Usage.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/rich-text-editor/Usage.jsx
@@ -47,6 +47,8 @@ export default function Usage() {
         label="Style"
         style={{ backgroundColor: "#ed7321", minHeight: "200px", opacity: 0.3 }}
       />
+      <div style={style} />
+      <RichTextEditor id="editor-disabled" label="Disabled" disabled />
     </Form>
   );
 }

--- a/packages/riipen-ui/package.json
+++ b/packages/riipen-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riipen-ui",
-  "version": "0.4.28",
+  "version": "0.4.29",
   "private": false,
   "author": {
     "name": "Riipen",

--- a/packages/riipen-ui/src/components/Editor.jsx
+++ b/packages/riipen-ui/src/components/Editor.jsx
@@ -69,6 +69,11 @@ class Editor extends React.Component {
     controlPosition: PropTypes.oneOf(["top", "bottom"]),
 
     /**
+     * Disable the editor or not
+     */
+    disabled: PropTypes.bool,
+
+    /**
      * The decorator for the editor.
      */
     decorator: PropTypes.shape({ type: PropTypes.oneOf([CompositeDecorator]) }),
@@ -171,6 +176,12 @@ class Editor extends React.Component {
         transition: ${theme.transitions.duration.standard}ms all;
         width: 100%;
         word-break: break-word;
+      }
+
+      .wrapper.disabled {
+        border-color: ${theme.palette.grey[400]};
+        opacity: 0.5;
+        pointer-events: none;
       }
 
       .wrapper.focus {
@@ -576,6 +587,7 @@ class Editor extends React.Component {
   render() {
     const {
       ariaLabelledBy,
+      disabled,
       error,
       controlPosition,
       placeholder,
@@ -591,6 +603,7 @@ class Editor extends React.Component {
     const wrapperClasses = clsx(
       linkedStyles.className,
       "wrapper",
+      disabled && "disabled",
       editorState.getSelection().getHasFocus() && "focus",
       error && "error"
     );
@@ -606,6 +619,7 @@ class Editor extends React.Component {
     const editorClasses = clsx(
       linkedStyles.className,
       "editor",
+      disabled && "disabled",
       controlPosition,
       hidePlaceholder && "richTextEditor-hidePlaceholder"
     );
@@ -627,6 +641,7 @@ class Editor extends React.Component {
               placeholder={placeholder}
               ref={this.editor}
               spellCheck
+              readOnly={disabled}
             />
           </div>
           {controlPosition === "bottom" && this.renderControls()}

--- a/packages/riipen-ui/src/components/Editor.jsx
+++ b/packages/riipen-ui/src/components/Editor.jsx
@@ -1,5 +1,4 @@
 import clsx from "clsx";
-import { convertFromHTML, convertToHTML } from "draft-convert";
 import {
   AtomicBlockUtils,
   CompositeDecorator,
@@ -19,63 +18,7 @@ import ThemeContext from "../styles/ThemeContext";
 import EditorBlockStyleControls from "./EditorBlockStyleControls";
 import EditorInlineStyleControls from "./EditorInlineStyleControls";
 import EditorImage from "./EditorImage";
-
-// draft-convert configuration for converting HTML to EditorState.
-export const fromHtmlConfig = {
-  htmlToEntity: (nodeName, node, createEntity) => {
-    switch (nodeName) {
-      case "a":
-        return createEntity("LINK", "MUTABLE", { url: node.href });
-      case "img":
-        return createEntity("IMAGE", "IMMUTABLE", {
-          alt: node.alt,
-          src: node.src
-        });
-      default:
-        return null;
-    }
-  },
-  htmlToBlock: nodeName => {
-    switch (nodeName) {
-      case "div":
-        return {
-          type: "atomic",
-          data: {}
-        };
-      default:
-        return null;
-    }
-  }
-};
-
-// draft-convert configuration for converting EditorState to HTML.
-const toHtmlConfig = {
-  blockToHTML: block => {
-    switch (block.type) {
-      case "code-block":
-        return <pre />;
-      case "atomic":
-        return <div />;
-      case "section":
-        return <section />;
-      case "unstyled":
-        return <p />;
-      default:
-        return null;
-    }
-  },
-  entityToHTML: (entity, originalText) => {
-    switch (entity.type) {
-      case "LINK":
-        return <a href={entity.data.url}>{originalText}</a>;
-
-      case "IMAGE":
-        return <img alt={entity.data.alt} src={entity.data.src} />;
-      default:
-        return originalText;
-    }
-  }
-};
+import EditorUtils from "./EditorUtils";
 
 // draft-js map of inline style types to the corresponding style displayed in the editor.
 const styleMap = {
@@ -194,7 +137,7 @@ class Editor extends React.Component {
     // Sets editor state after mount (because SSR)
     const editorState = initialValue
       ? EditorState.createWithContent(
-          convertFromHTML(fromHtmlConfig)(initialValue || ""),
+          EditorUtils.fromHtml(initialValue || ""),
           decorator
         )
       : EditorState.createEmpty(decorator);
@@ -366,7 +309,7 @@ class Editor extends React.Component {
   setHtml = async html => {
     const { decorator, autoFocus } = this.props;
 
-    const contentState = convertFromHTML(fromHtmlConfig)(html || "");
+    const contentState = EditorUtils.fromHtml(html || "");
     const editorState = EditorState.createWithContent(contentState, decorator);
 
     await this.onChange(editorState);
@@ -377,9 +320,7 @@ class Editor extends React.Component {
   };
 
   getHtml = () => {
-    const html = convertToHTML(toHtmlConfig)(
-      this.state.editorState.getCurrentContent()
-    );
+    const html = EditorUtils.toHtml(this.state.editorState.getCurrentContent());
     return this.hasContent() ? html : "";
   };
 
@@ -476,7 +417,7 @@ class Editor extends React.Component {
       text
     );
     const contentStateWithEntity = newContentState.createEntity(
-      "LINK",
+      EditorUtils.EDITOR_ENTITY_TYPES.LINK,
       "MUTABLE",
       { url }
     );
@@ -514,12 +455,6 @@ class Editor extends React.Component {
 
     this.onChange(editorStateWithLink);
   };
-
-  /**
-   * @typedef {Object} Block - object containing range which to remove links from
-   * @property {number} start - start position of selection range
-   * @property {number} end - end position of selection range
-   */
 
   /**
    * Control button callback for toggling removing links.
@@ -566,7 +501,7 @@ class Editor extends React.Component {
 
     const contentState = editorState.getCurrentContent();
     const contentStateWithEntity = contentState.createEntity(
-      "IMAGE",
+      EditorUtils.EDITOR_ENTITY_TYPES.IMAGE,
       "IMMUTABLE",
       {
         alt: altText,

--- a/packages/riipen-ui/src/components/EditorDecorator.jsx
+++ b/packages/riipen-ui/src/components/EditorDecorator.jsx
@@ -1,0 +1,3 @@
+import { CompositeDecorator } from "draft-js";
+
+export default CompositeDecorator;

--- a/packages/riipen-ui/src/components/EditorUtils.jsx
+++ b/packages/riipen-ui/src/components/EditorUtils.jsx
@@ -1,0 +1,221 @@
+import { convertFromHTML, convertToHTML } from "draft-convert";
+
+import React from "react";
+
+const EDITOR_ENTITY_TYPES = {
+  LINK: "LINK",
+  IMAGE: "IMAGE"
+};
+
+const fromHtmlConfig = {
+  htmlToEntity: (nodeName, node, createEntity) => {
+    switch (nodeName) {
+      case "a":
+        return createEntity(EDITOR_ENTITY_TYPES.LINK, "MUTABLE", {
+          url: node.href
+        });
+      case "img":
+        return createEntity(EDITOR_ENTITY_TYPES.IMAGE, "IMMUTABLE", {
+          alt: node.alt,
+          src: node.src
+        });
+      default:
+        return null;
+    }
+  },
+  htmlToBlock: nodeName => {
+    switch (nodeName) {
+      case "div":
+        return {
+          type: "atomic",
+          data: {}
+        };
+      default:
+        return null;
+    }
+  }
+};
+
+/**
+ * Wrapper of draft-convert convertFromHTML that has a predefined config.
+ *
+ * @param   {String} html - The html to convert into editor state
+ *
+ * @returns {Object} The RTE contentState (https://draftjs.org/docs/api-reference-content-state)
+ */
+const fromHtml = html => convertFromHTML(fromHtmlConfig)(html || "");
+
+const toHtmlConfig = {
+  blockToHTML: block => {
+    switch (block.type) {
+      case "code-block":
+        return <pre />;
+      case "atomic":
+        return <div />;
+      case "section":
+        return <section />;
+      case "unstyled":
+        return <p />;
+      default:
+        return null;
+    }
+  },
+  entityToHTML: (entity, originalText) => {
+    switch (entity.type) {
+      case EDITOR_ENTITY_TYPES.LINK:
+        return <a href={entity.data.url}>{originalText}</a>;
+      case EDITOR_ENTITY_TYPES.IMAGE:
+        return <img alt={entity.data.alt} src={entity.data.src} />;
+      default:
+        return originalText;
+    }
+  }
+};
+
+/**
+ * Wrapper of draft-convert convertFromHTML that has a predefined config.
+ *
+ * @param   {Object} contentState - The RTE contentState (https://draftjs.org/docs/api-reference-content-state)
+ *
+ * @returns {String} the html contained in the provided content state
+ */
+const toHtml = contentState => convertToHTML(toHtmlConfig)(contentState);
+
+const findEntities = (contentBlock, callback, contentState, entityType) => {
+  contentBlock.findEntityRanges(character => {
+    const entityKey = character.getEntity();
+    return (
+      entityKey !== null &&
+      (!entityType ||
+        contentState.getEntity(entityKey).getType() === entityType)
+    );
+  }, callback);
+};
+
+// find all content blocks within a selection range
+const getSelectedBlocks = (selection, contentState) => {
+  const startKey = selection.getStartKey();
+  const endKey = selection.getEndKey();
+  const blocks = contentState.getBlockMap();
+
+  let lastWasEnd = false;
+  return blocks
+    .skipUntil(block => block.getKey() === startKey)
+    .takeUntil(block => {
+      if (lastWasEnd) return true;
+
+      if (block.getKey() === endKey) {
+        lastWasEnd = true;
+      }
+
+      return false;
+    });
+};
+
+/**
+ * Get the selection ranges for entities of a given type within a selection range
+ *
+ * @param  {Object} selectionState - The RTE selectionState (https://draftjs.org/docs/api-reference-selection-state)
+ * @param  {Object} contentState   - The RTE contentState (https://draftjs.org/docs/api-reference-content-state)
+ * @param  {String} entityType     - The entity type to find selection ranges for
+ *
+ * @return {Object} The selection ranges of desired entities within the total selection range
+ */
+const getSelectedEntities = (selection, contentState, entityType) => {
+  if (!selection || !contentState) return null;
+
+  const startKey = selection.getStartKey();
+  const endKey = selection.getEndKey();
+  const selectedBlocks = getSelectedBlocks(selection, contentState);
+
+  const entityRanges = {};
+  let found = false;
+
+  selectedBlocks.forEach(block => {
+    const key = block.getKey();
+    entityRanges[key] = [];
+
+    let start = 0;
+    let end = block.getText().length;
+
+    if (key === startKey) {
+      start = selection.getStartOffset();
+    }
+    if (key === endKey) {
+      end = selection.getEndOffset();
+    }
+
+    findEntities(
+      block,
+      (entityStart, entityEnd) => {
+        const startBefore = start < entityStart && end > entityStart;
+        const endAfter = end > entityEnd && start < entityEnd;
+
+        const startWithin = start > entityStart && start < entityEnd;
+        const endWithin = end > entityStart && end < entityEnd;
+        const selectionInside = startWithin || endWithin;
+
+        const exactSelection = start === entityStart && end === entityEnd;
+
+        if (startBefore || endAfter || selectionInside || exactSelection) {
+          entityRanges[key].push({ start: entityStart, end: entityEnd });
+          found = true;
+        }
+      },
+      contentState,
+      entityType
+    );
+  });
+
+  return {
+    entityRanges,
+    found
+  };
+};
+
+/**
+ * Get the text currently selected in the RichTextEditor
+ * see: https://github.com/facebook/draft-js/issues/442#issuecomment-223816158
+ *
+ * @param  {Object} selectionState - The RTE selectionState (https://draftjs.org/docs/api-reference-selection-state)
+ * @param  {Object} contentState   - The RTE contentState (https://draftjs.org/docs/api-reference-content-state)
+ * @param  {String} blockDelimiter - Delimiter to join separate selected blocks
+ *
+ * @return {String} The selected text in the editor as a string
+ */
+const getSelectedText = (selection, contentState, blockDelimiter = "\n") => {
+  if (!selection || !contentState) return null;
+
+  const startKey = selection.getStartKey();
+  const endKey = selection.getEndKey();
+  const selectedBlock = getSelectedBlocks(selection, contentState);
+
+  return selectedBlock
+    .map(block => {
+      const key = block.getKey();
+      let text = block.getText();
+
+      let start = 0;
+      let end = text.length;
+
+      if (key === startKey) {
+        start = selection.getStartOffset();
+      }
+      if (key === endKey) {
+        end = selection.getEndOffset();
+      }
+
+      text = text.slice(start, end);
+      return text;
+    })
+    .join(blockDelimiter);
+};
+
+export default {
+  EDITOR_ENTITY_TYPES,
+  findEntities,
+  fromHtml,
+  getSelectedEntities,
+  getSelectedText,
+  toHtml
+};

--- a/packages/riipen-ui/src/components/EditorUtils.test.jsx
+++ b/packages/riipen-ui/src/components/EditorUtils.test.jsx
@@ -1,0 +1,21 @@
+import EditorUtils from "./EditorUtils";
+
+describe("<EditorUtils>", () => {
+  describe("fromHtml", () => {
+    it("removes tags", () => {
+      const result = EditorUtils.fromHtml("<p>test</p>").getPlainText();
+      expect(result).toEqual(`test`);
+    });
+
+    it("decodes html codes", () => {
+      const result = EditorUtils.fromHtml("test &amp; &#39;").getPlainText();
+      expect(result).toEqual(`test & '`);
+    });
+
+    it("returns empty string with undefined value", () => {
+      const result = EditorUtils.fromHtml().getPlainText();
+
+      expect(result).toEqual("");
+    });
+  });
+});

--- a/packages/riipen-ui/src/components/index.js
+++ b/packages/riipen-ui/src/components/index.js
@@ -20,11 +20,13 @@ export {
   default as EditorBlockStyleControls
 } from "./EditorBlockStyleControls";
 export { default as EditorControlButton } from "./EditorControlButton";
+export { default as EditorDecorator } from "./EditorDecorator";
 export { default as EditorImage } from "./EditorImage";
 export {
   default as EditorInlineStyleControls
 } from "./EditorInlineStyleControls";
 export { default as EditorLink } from "./EditorLink";
+export { default as EditorUtils } from "./EditorUtils";
 export { default as Form } from "./Form";
 export { default as FormGroup } from "./FormGroup";
 export { default as Grid } from "./Grid";


### PR DESCRIPTION
## Description

Add EditorUtils, collection of editor content manipulation functions.
Small Updates to RTE.

## Notes

These for sure could live on the web, ive opted to move them here as they directly work with draft js objects. Once we do this the frontend no longer needs draft-js or draft-convert as dependencies

## Screenshots

## Where to Start
