### PR TITLE
Update tooltip top/bottom padding to be a bit smaller in small size

### DIFF
--- a/packages/riipen-ui/src/components/Tooltip.jsx
+++ b/packages/riipen-ui/src/components/Tooltip.jsx
@@ -150,7 +150,7 @@ class Tooltip extends React.Component {
       /* Sizes */
 
       .popover.small {
-        padding: ${theme.spacing(2)}px ${theme.spacing(4)}px;
+        padding: ${theme.spacing(1)}px ${theme.spacing(4)}px;
       }
 
       .popover.medium {


### PR DESCRIPTION
## Description
Update small tooltip top/bottom padding to be a bit smaller.

## Screenshots
<img width="273" alt="Screen Shot 2021-05-06 at 12 48 18 PM" src="https://user-images.githubusercontent.com/10818279/117357247-8caed800-ae69-11eb-9513-47fb19d42a89.png">


## Where to Start
