### PR TITLE
[PLT-7482] Update default input placeholder text colour for Editor

### DIFF
--- a/packages/riipen-ui/src/components/Editor.jsx
+++ b/packages/riipen-ui/src/components/Editor.jsx
@@ -284,7 +284,7 @@ class Editor extends React.Component {
       }
 
       :global(.public-DraftEditorPlaceholder-inner) {
-        color: ${theme.palette.text.disabled};
+        color: ${theme.palette.grey[400]};
       }
 
       :global(.public-DraftEditorPlaceholder-root) {


### PR DESCRIPTION
## Description
Updating the placeholder input text colour  to `grey400` in Rich Text Editors to be consistent with `platform-web`

Original PR: https://github.com/riipen/platform-web/pull/4140

## Screenshots

<img width="629" alt="Screen Shot 2021-05-17 at 9 50 34 AM" src="https://user-images.githubusercontent.com/61811702/118526728-656fca80-b6f5-11eb-9df7-b76226ef5fdb.png">

