### PR TITLE
Pass onBlur prop to Draftjs in Editor component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ out/
 
 # macOS output
 .DS_Store
+
+# VSCode settings
+.vscode

--- a/packages/riipen-ui/src/components/Editor.jsx
+++ b/packages/riipen-ui/src/components/Editor.jsx
@@ -99,6 +99,11 @@ class Editor extends React.Component {
     onChange: PropTypes.func,
 
     /**
+     * Function to execute when editor is out of focus.
+     */
+    onBlur: PropTypes.func,
+
+    /**
      * The max height of the Editor text area.
      */
     maxHeight: PropTypes.string,
@@ -587,9 +592,10 @@ class Editor extends React.Component {
   render() {
     const {
       ariaLabelledBy,
+      controlPosition,
       disabled,
       error,
-      controlPosition,
+      onBlur,
       placeholder,
       style
     } = this.props;
@@ -637,6 +643,7 @@ class Editor extends React.Component {
               editorState={editorState}
               handleKeyCommand={this.handleKeyCommand}
               keyBindingFn={this.myKeyBindingFn}
+              onBlur={onBlur}
               onChange={this.onChange}
               placeholder={placeholder}
               ref={this.editor}


### PR DESCRIPTION
## Description
This is part of this [ticket](https://riipen.atlassian.net/browse/PLT-7426) for trimming whitespace in our inputs. The idea is we trim whitespace when the input is out of focus. In order to do this, we need onBlur event to be triggered on our rich text editor.

## Notes

## Screenshots

## Where to Start
