### PR TITLE
Add .prettierrc

### DIFF
--- a/packages/riipen-ui/.prettierrc
+++ b/packages/riipen-ui/.prettierrc
@@ -1,0 +1,5 @@
+{
+    "singleQuote": false,
+    "trailingComma": "all",
+    "arrowParens": "always"
+  }


### PR DESCRIPTION
## Description
In ui, we use double quotes instead of single quotes.
Add a prettier config file so that saving a file in ui
doesn't result in a bunch of lint issues.
## Notes

## Screenshots

## Where to Start
