### PR TITLE
[PLT-7534] Add color prop to Avatar

### DIFF
--- a/packages/riipen-ui/.prettierrc
+++ b/packages/riipen-ui/.prettierrc
@@ -1,5 +1,3 @@
 {
-    "singleQuote": false,
-    "trailingComma": "all",
-    "arrowParens": "always"
-  }
+  "singleQuote": false
+}

--- a/packages/riipen-ui/.prettierrc
+++ b/packages/riipen-ui/.prettierrc
@@ -1,0 +1,5 @@
+{
+    "singleQuote": false,
+    "trailingComma": "all",
+    "arrowParens": "always"
+  }

--- a/packages/riipen-ui/src/components/Avatar.jsx
+++ b/packages/riipen-ui/src/components/Avatar.jsx
@@ -28,7 +28,7 @@ class Avatar extends React.Component {
     /**
      * The color of the background for the Avatar
      */
-    backgroundColor: PropTypes.oneOf(["grey", "white"]),
+    backgroundColor: PropTypes.oneOf(["grey200", "white"]),
 
     /**
      * The height and width size to render the Avatar at.
@@ -48,7 +48,7 @@ class Avatar extends React.Component {
 
   static defaultProps = {
     classes: [],
-    backgroundColor: "grey",
+    backgroundColor: "grey200",
     size: "96px",
     variant: "circle"
   };
@@ -117,7 +117,7 @@ class Avatar extends React.Component {
             user-select: none;
           }
 
-          .background-grey {
+          .background-grey200 {
             background-color: ${theme.palette.grey[200]};
           }
 

--- a/packages/riipen-ui/src/components/Avatar.jsx
+++ b/packages/riipen-ui/src/components/Avatar.jsx
@@ -26,6 +26,11 @@ class Avatar extends React.Component {
     classes: PropTypes.array,
 
     /**
+     * The color of the background for the Avatar
+     */
+    color: PropTypes.oneOf(["grey", "white"]),
+
+    /**
      * The height and width size to render the Avatar at.
      */
     size: PropTypes.string.isRequired,
@@ -38,13 +43,14 @@ class Avatar extends React.Component {
     /**
      * The shape of the avatar.
      */
-    variant: PropTypes.oneOf(["circle", "rounded", "square"])
+    variant: PropTypes.oneOf(["circle", "rounded", "square"]),
   };
 
   static defaultProps = {
     classes: [],
+    color: "grey",
     size: "96px",
-    variant: "circle"
+    variant: "circle",
   };
 
   getBorderSize() {
@@ -64,11 +70,20 @@ class Avatar extends React.Component {
   static contextType = ThemeContext;
 
   render() {
-    const { alt, children, classes, size, src, variant, ...other } = this.props;
+    const {
+      alt,
+      children,
+      classes,
+      color,
+      size,
+      src,
+      variant,
+      ...other
+    } = this.props;
 
     const theme = this.context;
 
-    const className = clsx("avatar", variant, classes);
+    const className = clsx("avatar", variant, classes, color);
 
     return (
       <React.Fragment>
@@ -83,7 +98,6 @@ class Avatar extends React.Component {
         </span>
         <style jsx>{`
           .avatar {
-            background-color: ${theme.palette.grey[200]};
             border: ${this.getBorderSize()} solid ${theme.palette.common.white};
             display: inline-block;
             font-family: ${theme.typography.fontFamily};
@@ -96,6 +110,10 @@ class Avatar extends React.Component {
             min-width: ${size};
             overflow: hidden;
             user-select: none;
+          }
+
+          .grey {
+            background-color: ${theme.palette.grey[200]};
           }
 
           .circle {
@@ -119,8 +137,13 @@ class Avatar extends React.Component {
           .rounded {
             border-radius: ${theme.shape.borderRadius.md};
           }
+
           .square {
             border-radius: 0px;
+          }
+
+          .white {
+            background-color: ${theme.palette.common.white};
           }
         `}</style>
       </React.Fragment>

--- a/packages/riipen-ui/src/components/Avatar.jsx
+++ b/packages/riipen-ui/src/components/Avatar.jsx
@@ -28,7 +28,7 @@ class Avatar extends React.Component {
     /**
      * The color of the background for the Avatar
      */
-    color: PropTypes.oneOf(["grey", "white"]),
+    backgroundColor: PropTypes.oneOf(["grey", "white"]),
 
     /**
      * The height and width size to render the Avatar at.
@@ -43,14 +43,14 @@ class Avatar extends React.Component {
     /**
      * The shape of the avatar.
      */
-    variant: PropTypes.oneOf(["circle", "rounded", "square"]),
+    variant: PropTypes.oneOf(["circle", "rounded", "square"])
   };
 
   static defaultProps = {
     classes: [],
-    color: "grey",
+    backgroundColor: "grey",
     size: "96px",
-    variant: "circle",
+    variant: "circle"
   };
 
   getBorderSize() {
@@ -72,9 +72,9 @@ class Avatar extends React.Component {
   render() {
     const {
       alt,
+      backgroundColor,
       children,
       classes,
-      color,
       size,
       src,
       variant,
@@ -83,7 +83,12 @@ class Avatar extends React.Component {
 
     const theme = this.context;
 
-    const className = clsx("avatar", variant, classes, color);
+    const className = clsx(
+      "avatar",
+      variant,
+      classes,
+      `background-${backgroundColor}`
+    );
 
     return (
       <React.Fragment>
@@ -112,8 +117,12 @@ class Avatar extends React.Component {
             user-select: none;
           }
 
-          .grey {
+          .background-grey {
             background-color: ${theme.palette.grey[200]};
+          }
+
+          .background-white {
+            background-color: ${theme.palette.common.white};
           }
 
           .circle {
@@ -140,10 +149,6 @@ class Avatar extends React.Component {
 
           .square {
             border-radius: 0px;
-          }
-
-          .white {
-            background-color: ${theme.palette.common.white};
           }
         `}</style>
       </React.Fragment>

--- a/packages/riipen-ui/src/components/__snapshots__/Avatar.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Avatar.test.jsx.snap
@@ -9,20 +9,20 @@ exports[`<Avatar> renders correct snapshot 1`] = `
         "riipen-avatar",
       ]
     }
+    color="grey"
     size="96px"
     variant="circle"
   >
     <span
-      className="jsx-3881544049 avatar circle riipen riipen-avatar"
+      className="jsx-888354494 avatar circle riipen riipen-avatar grey"
     >
       <span
-        className="jsx-3881544049 inner"
+        className="jsx-888354494 inner"
       />
     </span>
     <JSXStyle
       dynamic={
         Array [
-          "#eeeeee",
           "4px",
           "#fff",
           "Roboto, Helvetica, Arial, sans-serif",
@@ -32,10 +32,12 @@ exports[`<Avatar> renders correct snapshot 1`] = `
           "96px",
           "96px",
           "96px",
+          "#eeeeee",
           "4px",
+          "#fff",
         ]
       }
-      id="4017156812"
+      id="1416698901"
     />
   </Avatar>
 </withClasses(Avatar)>

--- a/packages/riipen-ui/src/components/__snapshots__/Avatar.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Avatar.test.jsx.snap
@@ -3,21 +3,21 @@
 exports[`<Avatar> renders correct snapshot 1`] = `
 <withClasses(Avatar)>
   <Avatar
+    backgroundColor="grey"
     classes={
       Array [
         "riipen",
         "riipen-avatar",
       ]
     }
-    color="grey"
     size="96px"
     variant="circle"
   >
     <span
-      className="jsx-888354494 avatar circle riipen riipen-avatar grey"
+      className="jsx-3275828585 avatar circle riipen riipen-avatar background-grey"
     >
       <span
-        className="jsx-888354494 inner"
+        className="jsx-3275828585 inner"
       />
     </span>
     <JSXStyle
@@ -33,11 +33,11 @@ exports[`<Avatar> renders correct snapshot 1`] = `
           "96px",
           "96px",
           "#eeeeee",
-          "4px",
           "#fff",
+          "4px",
         ]
       }
-      id="1416698901"
+      id="364247947"
     />
   </Avatar>
 </withClasses(Avatar)>

--- a/packages/riipen-ui/src/components/__snapshots__/Avatar.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Avatar.test.jsx.snap
@@ -3,7 +3,7 @@
 exports[`<Avatar> renders correct snapshot 1`] = `
 <withClasses(Avatar)>
   <Avatar
-    backgroundColor="grey"
+    backgroundColor="grey200"
     classes={
       Array [
         "riipen",
@@ -14,10 +14,10 @@ exports[`<Avatar> renders correct snapshot 1`] = `
     variant="circle"
   >
     <span
-      className="jsx-3275828585 avatar circle riipen riipen-avatar background-grey"
+      className="jsx-3146849499 avatar circle riipen riipen-avatar background-grey200"
     >
       <span
-        className="jsx-3275828585 inner"
+        className="jsx-3146849499 inner"
       />
     </span>
     <JSXStyle
@@ -37,7 +37,7 @@ exports[`<Avatar> renders correct snapshot 1`] = `
           "4px",
         ]
       }
-      id="364247947"
+      id="1174196656"
     />
   </Avatar>
 </withClasses(Avatar)>


### PR DESCRIPTION
## Description
* Add a `color` prop to `<Avatar>`, defaults to "grey" and can be one of "grey" or "white"
## Notes
* required for https://github.com/riipen/platform-web/pull/4242
## Screenshots
Avatar with background white, others with default grey background
![Screen Shot 2021-06-01 at 3 08 07 PM](https://user-images.githubusercontent.com/36321777/120381660-bb955e00-c2f0-11eb-8fc3-c31a920cea89.png)

## Where to Start
