### PR TITLE
Update InputLabel default color to greyA400 and font weight medium

### DIFF
--- a/packages/riipen-ui/src/components/InputLabel.jsx
+++ b/packages/riipen-ui/src/components/InputLabel.jsx
@@ -42,7 +42,6 @@ const InputLabel = ({
       {hint && <InputHint color={color}>{hint}</InputHint>}
       <style jsx>{`
         label {
-          color: ${theme.palette.text.secondary};
           display: inline-block;
           margin-bottom: ${theme.spacing(marginBottom)}px;
         }
@@ -98,8 +97,8 @@ InputLabel.propTypes = {
 
 InputLabel.defaultProps = {
   classes: [],
-  color: "inherit",
-  fontWeight: "regular",
+  color: "greyA400",
+  fontWeight: "medium",
   required: false,
   variant: "h5"
 };

--- a/packages/riipen-ui/src/components/__snapshots__/InputLabel.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/InputLabel.test.jsx.snap
@@ -221,8 +221,8 @@ exports[`<InputLabel> renders correct snapshot 1`] = `
           "riipen-inputlabel",
         ]
       }
-      color="inherit"
-      fontWeight="regular"
+      color="greyA400"
+      fontWeight="medium"
       required={false}
       theme={
         Object {
@@ -439,11 +439,10 @@ exports[`<InputLabel> renders correct snapshot 1`] = `
       <JSXStyle
         dynamic={
           Array [
-            "#747474",
             15,
           ]
         }
-        id="873900508"
+        id="517714963"
       />
     </InputLabel>
   </withClasses(InputLabel)>


### PR DESCRIPTION
## Description
Update InputLabel to have default fontWeight = medium and color = greyA400

## Screenshots
![Screenshot_2021-06-03 Input Riipen UI](https://user-images.githubusercontent.com/10818279/120720214-8e77b580-c480-11eb-930f-f6ca972ce69e.png)

## Where to Start
src/components/InputLabel.jsx
