### PR TITLE
Mobile menu for UI Riipen page

### DIFF
--- a/packages/riipen-ui-docs/src/modules/components/MarkdownPage.jsx
+++ b/packages/riipen-ui-docs/src/modules/components/MarkdownPage.jsx
@@ -25,6 +25,7 @@ const MarkdownPage = ({ req, path, reqSource, title }) => {
   const [menuOpen, setMenuOpen] = React.useState(false);
 
   const handleMenuOpen = (event) => {
+    document.body.style.overflow = menuOpen ? "auto" : "hidden";
     setAnchorState(menuOpen ? null : event.currentTarget);
     setMenuOpen(!menuOpen);
   };
@@ -55,29 +56,28 @@ const MarkdownPage = ({ req, path, reqSource, title }) => {
       <Head>
         <title>{title ? `${title} | ` : ""}Riipen UI</title>
       </Head>
-      <AppBar>
+      <AppBar classes={["appBar"]}>
         <Link href="/" color="inherit">
           Riipen-UI
         </Link>
         <div className="menuMobile">
-          <React.Fragment>
-            <ButtonIcon color="white" onClick={handleMenuOpen}>
-              <FontAwesomeIcon icon={menuOpen ? faTimes : faBars} />
-            </ButtonIcon>
-            <Popover
-              anchorEl={anchorState}
-              anchorPosition={{
-                vertical: "bottom",
-                horizontal: "center"
-              }}
-              closeOnScrolled={false}
-              fullWidth
-              isOpen={menuOpen}
-              lockScroll
-            >
-              <Menu />
-            </Popover>
-          </React.Fragment>
+          <ButtonIcon color="white" onClick={handleMenuOpen}>
+            <FontAwesomeIcon icon={menuOpen ? faTimes : faBars} />
+          </ButtonIcon>
+          <Popover
+            anchorEl={anchorState}
+            anchorPosition={{ horizontal: "center", vertical: "bottom" }}
+            classes={["menuPopover"]}
+            contentPosition={{
+              horizontal: "center",
+              vertical: "top"
+            }}
+            closeOnScrolled={false}
+            fullWidth
+            isOpen={menuOpen}
+          >
+            <Menu />
+          </Popover>
         </div>
       </AppBar>
       <div className="page">
@@ -122,6 +122,9 @@ const MarkdownPage = ({ req, path, reqSource, title }) => {
         </div>
       </div>
       <style jsx>{`
+        :global(.appBar) {
+          justify-content: space-between;
+        }
         .page {
           display: flex;
           justify-content: space-between;
@@ -144,7 +147,11 @@ const MarkdownPage = ({ req, path, reqSource, title }) => {
         .menuMobile {
           display: none;
         }
-        .menuMobile :global(.popover) {
+        :global(.menuPopover) {
+          margin: ${theme.spacing(3)}px ${theme.spacing(2)}px;
+          max-height: calc(100% - ${theme.spacing(13)}px) !important;
+          max-width: calc(100% - ${theme.spacing(4)}px) !important;
+          padding: ${theme.spacing(2)}px;
           overflow-y: auto;
         }
         .toc {
@@ -161,7 +168,6 @@ const MarkdownPage = ({ req, path, reqSource, title }) => {
 
           .menuMobile {
             display: initial;
-            margin-left: auto;
           }
         }
         .footer {

--- a/packages/riipen-ui-docs/src/modules/components/MarkdownPage.jsx
+++ b/packages/riipen-ui-docs/src/modules/components/MarkdownPage.jsx
@@ -1,6 +1,13 @@
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faBars } from "@fortawesome/free-solid-svg-icons";
 import Head from "next/head";
 import PropTypes from "prop-types";
 import React from "react";
+import AppBar from "riipen-ui/components/AppBar";
+import ButtonIcon from "riipen-ui/components/ButtonIcon";
+import Divider from "riipen-ui/components/Divider";
+import Popover from "riipen-ui/components/Popover";
+import ThemeContext from "riipen-ui/styles/ThemeContext";
 
 import constants from "src/constants";
 import Demo from "src/modules/components/Demo";
@@ -11,141 +18,164 @@ import Menu from "src/modules/components/Menu";
 import TOC from "src/modules/components/TOC";
 import { getSections } from "src/utils/parseMarkdown";
 
-import AppBar from "riipen-ui/components/AppBar";
-import Divider from "riipen-ui/components/Divider";
-import ThemeContext from "riipen-ui/styles/ThemeContext";
+const MarkdownPage = ({ req, path, reqSource, title }) => {
+  const theme = React.useContext(ThemeContext);
 
-class MarkdownPage extends React.Component {
-  static propTypes = {
-    path: PropTypes.string.isRequired,
-    req: PropTypes.func.isRequired,
-    reqSource: PropTypes.func,
-    title: PropTypes.string
+  const [anchorState, setAnchorState] = React.useState(null);
+  const [menuOpen, setMenuOpen] = React.useState(false);
+
+  const handleMenuOpen = (event) => {
+    setAnchorState(menuOpen ? null : event.currentTarget);
+    setMenuOpen(!menuOpen);
   };
 
-  static contextType = ThemeContext;
+  const demos = {};
+  let markdown;
 
-  render() {
-    const { req, path, reqSource, title } = this.props;
+  req.keys().forEach((filename) => {
+    if (filename.indexOf(".md") !== -1) {
+      markdown = req(filename).default;
+    } else if (filename.indexOf(".jsx") !== -1) {
+      const demoName = `${path}/${filename
+        .replace(/\.\//g, "")
+        .replace(/\.jsx/g, ".js")}`;
 
-    const theme = this.context;
+      demos[demoName] = {
+        name: demoName,
+        jsx: req(filename).default,
+        rawJS: reqSource(filename).default
+      };
+    }
+  });
 
-    const demos = {};
-    let markdown;
+  const sections = getSections(markdown);
 
-    req.keys().forEach(filename => {
-      if (filename.indexOf(".md") !== -1) {
-        markdown = req(filename).default;
-      } else if (filename.indexOf(".jsx") !== -1) {
-        const demoName = `${path}/${filename
-          .replace(/\.\//g, "")
-          .replace(/\.jsx/g, ".js")}`;
+  return (
+    <div>
+      <Head>
+        <title>{title ? `${title} | ` : ""}Riipen UI</title>
+      </Head>
+      <AppBar>
+        <Link href="/" color="inherit">
+          Riipen-UI
+        </Link>
+        <div className="menuMobile">
+          <React.Fragment>
+            <ButtonIcon color="white" onClick={handleMenuOpen}>
+              <FontAwesomeIcon icon={faBars} />
+            </ButtonIcon>
+            <Popover
+              anchorEl={anchorState}
+              closeOnScrolled={false}
+              fullWidth
+              isOpen={menuOpen}
+              lockScroll
+            >
+              <Menu />
+            </Popover>
+          </React.Fragment>
+        </div>
+      </AppBar>
+      <div className="page">
+        <div className="menu">
+          <Menu />
+        </div>
+        <div className="content">
+          {sections.map((section, index) => {
+            if (demos && constants.REGEX.DEMO.test(section)) {
+              let options;
 
-        demos[demoName] = {
-          name: demoName,
-          jsx: req(filename).default,
-          rawJS: reqSource(filename).default
-        };
-      }
-    });
+              try {
+                options = JSON.parse(`{${section}}`);
+              } catch (err) {
+                console.error(err);
+                return null;
+              }
 
-    const sections = getSections(markdown);
+              const name = options.demo;
 
-    return (
-      <div>
-        <Head>
-          <title>{title ? `${title} | ` : ""}Riipen UI</title>
-        </Head>
-        <AppBar>
-          <Link href="/" color="inherit">
-            Riipen-UI
-          </Link>
-        </AppBar>
-        <div className="page">
-          <div className="menu">
-            <Menu />
-          </div>
-          <div className="content">
-            {sections.map((section, index) => {
-              if (demos && constants.REGEX.DEMO.test(section)) {
-                let options;
-
-                try {
-                  options = JSON.parse(`{${section}}`);
-                } catch (err) {
-                  console.error(err);
-                  return null;
-                }
-
-                const name = options.demo;
-
-                if (!demos || !demos[name]) {
-                  throw new Error(
-                    [
-                      `Missing demo: ${name}. You can use one of the following:`,
-                      Object.keys(demos)
-                    ].join("\n")
-                  );
-                }
-
-                return (
-                  <Demo key={index} demo={demos[name]} options={options} />
+              if (!demos || !demos[name]) {
+                throw new Error(
+                  [
+                    `Missing demo: ${name}. You can use one of the following:`,
+                    Object.keys(demos)
+                  ].join("\n")
                 );
               }
 
-              return <MarkdownElement key={index} text={section} />;
-            })}
-            <div className="footer">
-              <Divider />
-              <Footer />
-            </div>
-          </div>
-          <div className="toc">
-            <TOC sections={sections} />
+              return <Demo key={index} demo={demos[name]} options={options} />;
+            }
+
+            return <MarkdownElement key={index} text={section} />;
+          })}
+          <div className="footer">
+            <Divider />
+            <Footer />
           </div>
         </div>
-        <style jsx>{`
-          .page {
-            display: flex;
-            justify-content: space-between;
-            padding-top: 22px;
-            position: relative;
-            top: 50px;
-            width: 100%;
-          }
-          .page :global(*:target) {
-            padding-top: 50px;
-          }
-          .content {
-            padding: 0 20px;
-            overflow-x: auto;
-            width: 100%;
-          }
-          .menu {
-            padding: ${theme.spacing(2)}px;
-          }
-          .toc {
-            top: 70px;
-            position: sticky;
-            max-width: 250px;
-            min-width: 175px;
-          }
-          @media (max-width: ${theme.breakpoints.md}px) {
-            .menu,
-            .toc {
-              display: none;
-            }
-          }
-          .footer {
-            margin: ${theme.spacing(10)}px 0;
-          }
-          .footer :global(footer) {
-            margin-top: ${theme.spacing(10)}px;
-          }
-        `}</style>
+        <div className="toc">
+          <TOC sections={sections} />
+        </div>
       </div>
-    );
-  }
-}
+      <style jsx>{`
+        .page {
+          display: flex;
+          justify-content: space-between;
+          padding-top: 22px;
+          position: relative;
+          top: 50px;
+          width: 100%;
+        }
+        .page :global(*:target) {
+          padding-top: 50px;
+        }
+        .content {
+          padding: 0 20px;
+          overflow-x: auto;
+          width: 100%;
+        }
+        .menu {
+          padding: ${theme.spacing(2)}px;
+        }
+        .menuMobile {
+          display: none;
+        }
+        .menuMobile :global(.popover) {
+          overflow-y: auto;
+        }
+        .toc {
+          top: 70px;
+          position: sticky;
+          max-width: 250px;
+          min-width: 175px;
+        }
+        @media (max-width: ${theme.breakpoints.md}px) {
+          .menu,
+          .toc {
+            display: none;
+          }
+
+          .menuMobile {
+            display: initial;
+            margin-left: auto;
+          }
+        }
+        .footer {
+          margin: ${theme.spacing(10)}px 0;
+        }
+        .footer :global(footer) {
+          margin-top: ${theme.spacing(10)}px;
+        }
+      `}</style>
+    </div>
+  );
+};
+
+MarkdownPage.propTypes = {
+  path: PropTypes.string.isRequired,
+  req: PropTypes.func.isRequired,
+  reqSource: PropTypes.func,
+  title: PropTypes.string
+};
 
 export default MarkdownPage;

--- a/packages/riipen-ui-docs/src/modules/components/MarkdownPage.jsx
+++ b/packages/riipen-ui-docs/src/modules/components/MarkdownPage.jsx
@@ -1,5 +1,5 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faBars } from "@fortawesome/free-solid-svg-icons";
+import { faBars, faTimes } from "@fortawesome/free-solid-svg-icons";
 import Head from "next/head";
 import PropTypes from "prop-types";
 import React from "react";
@@ -62,10 +62,14 @@ const MarkdownPage = ({ req, path, reqSource, title }) => {
         <div className="menuMobile">
           <React.Fragment>
             <ButtonIcon color="white" onClick={handleMenuOpen}>
-              <FontAwesomeIcon icon={faBars} />
+              <FontAwesomeIcon icon={menuOpen ? faTimes : faBars} />
             </ButtonIcon>
             <Popover
               anchorEl={anchorState}
+              anchorPosition={{
+                vertical: "bottom",
+                horizontal: "center"
+              }}
               closeOnScrolled={false}
               fullWidth
               isOpen={menuOpen}

--- a/packages/riipen-ui-docs/src/modules/components/MarkdownPage.jsx
+++ b/packages/riipen-ui-docs/src/modules/components/MarkdownPage.jsx
@@ -8,6 +8,7 @@ import ButtonIcon from "riipen-ui/components/ButtonIcon";
 import Divider from "riipen-ui/components/Divider";
 import Popover from "riipen-ui/components/Popover";
 import ThemeContext from "riipen-ui/styles/ThemeContext";
+import css from "styled-jsx/css";
 
 import constants from "src/constants";
 import Demo from "src/modules/components/Demo";
@@ -29,6 +30,19 @@ const MarkdownPage = ({ req, path, reqSource, title }) => {
     setAnchorState(menuOpen ? null : event.currentTarget);
     setMenuOpen(!menuOpen);
   };
+
+  const linkedStyles = css.resolve`
+    .appBar {
+      justify-content: space-between;
+    }
+    .menuPopover {
+      margin: ${theme.spacing(3)}px ${theme.spacing(2)}px;
+      max-height: calc(100% - ${theme.spacing(13)}px) !important;
+      max-width: calc(100% - ${theme.spacing(4)}px) !important;
+      padding: ${theme.spacing(2)}px;
+      overflow-y: auto;
+    }
+  `;
 
   const demos = {};
   let markdown;
@@ -56,7 +70,7 @@ const MarkdownPage = ({ req, path, reqSource, title }) => {
       <Head>
         <title>{title ? `${title} | ` : ""}Riipen UI</title>
       </Head>
-      <AppBar classes={["appBar"]}>
+      <AppBar classes={[linkedStyles.className, "appBar"]}>
         <Link href="/" color="inherit">
           Riipen-UI
         </Link>
@@ -67,7 +81,7 @@ const MarkdownPage = ({ req, path, reqSource, title }) => {
           <Popover
             anchorEl={anchorState}
             anchorPosition={{ horizontal: "center", vertical: "bottom" }}
-            classes={["menuPopover"]}
+            classes={[linkedStyles.className, "menuPopover"]}
             contentPosition={{
               horizontal: "center",
               vertical: "top"
@@ -122,9 +136,6 @@ const MarkdownPage = ({ req, path, reqSource, title }) => {
         </div>
       </div>
       <style jsx>{`
-        :global(.appBar) {
-          justify-content: space-between;
-        }
         .page {
           display: flex;
           justify-content: space-between;
@@ -146,13 +157,6 @@ const MarkdownPage = ({ req, path, reqSource, title }) => {
         }
         .menuMobile {
           display: none;
-        }
-        :global(.menuPopover) {
-          margin: ${theme.spacing(3)}px ${theme.spacing(2)}px;
-          max-height: calc(100% - ${theme.spacing(13)}px) !important;
-          max-width: calc(100% - ${theme.spacing(4)}px) !important;
-          padding: ${theme.spacing(2)}px;
-          overflow-y: auto;
         }
         .toc {
           top: 70px;
@@ -177,6 +181,7 @@ const MarkdownPage = ({ req, path, reqSource, title }) => {
           margin-top: ${theme.spacing(10)}px;
         }
       `}</style>
+      {linkedStyles.styles}
     </div>
   );
 };

--- a/packages/riipen-ui-docs/src/modules/components/Menu.jsx
+++ b/packages/riipen-ui-docs/src/modules/components/Menu.jsx
@@ -6,6 +6,7 @@ import { faChevronDown } from "@fortawesome/free-solid-svg-icons";
 import Accordion from "riipen-ui/components/Accordion";
 import AccordionDetails from "riipen-ui/components/AccordionDetails";
 import AccordionSummary from "riipen-ui/components/AccordionSummary";
+import Typography from "riipen-ui/components/Typography";
 import ThemeContext from "riipen-ui/styles/ThemeContext";
 
 import Link from "src/modules/components/Link";
@@ -54,7 +55,9 @@ const Menu = () => {
           <li key={i}>
             <Accordion {...parent.props}>
               <AccordionSummary icon={Icon} iconProps={{ size: "small" }}>
-                {parent.name}
+                <Typography color="initial" fontWeight="bold" variant="h5">
+                  {parent.name}
+                </Typography>
               </AccordionSummary>
               <AccordionDetails>
                 <ul>{getLinks(parent)}</ul>
@@ -82,6 +85,11 @@ const Menu = () => {
         }
         li {
           padding: ${theme.spacing(1)}px;
+        }
+        @media (max-width: ${theme.breakpoints.md}px) {
+          div {
+            width: 100%;
+          }
         }
       `}</style>
     </div>


### PR DESCRIPTION
## Description
Add Menu for "mobile" view, as the left-hand menu disappears at smaller screen sizes.
Mostly a  proof of concept PR, definitely needs more work and cleaning up.

## Notes
Mostly a  proof of concept PR, definitely needs more work and cleaning up.

## Screenshots
![Screenshot_2021-06-03 App Bar API Riipen UI](https://user-images.githubusercontent.com/10818279/120872963-1a5b1180-c555-11eb-8b2d-0ea2b72fc089.png)
![Screenshot 2021-06-04 at 16-50-09 Badge Riipen UI](https://user-images.githubusercontent.com/10818279/120872973-247d1000-c555-11eb-9aca-0bffb8e10fdc.png)


## Where to Start
packages/riipen-ui-docs/src/modules/components/MarkdownPage.jsx 