### PR TITLE
Remove blur to stop focus stealing

### DIFF
--- a/packages/riipen-ui/src/components/Tooltip.jsx
+++ b/packages/riipen-ui/src/components/Tooltip.jsx
@@ -320,14 +320,6 @@ const Tooltip = ({
     `;
   };
 
-  const blur = () => {
-    // Unfocus if it is still active
-    const activeElement = document.activeElement;
-    if (activeElement) {
-      activeElement.blur();
-    }
-  };
-
   const handleOpen = () => {
     if (!isControlledByProps) setIsOpen(true);
     if (onOpen) {
@@ -336,7 +328,6 @@ const Tooltip = ({
   };
 
   const handleClose = () => {
-    blur();
     if (!isControlledByProps) setIsOpen(false);
     if (onClose) {
       onClose();


### PR DESCRIPTION
## Description
Blur was stealing the focus from Samsung keyboard, so yeet it outta here.

## Where to Start
components/Tooltip
