### PR TITLE
Update VerticalProgressBar to accept VerticalProgressBarItems as children

### DIFF
--- a/packages/riipen-ui-docs/src/pages/components/vertical-progress-bar/Color.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/vertical-progress-bar/Color.jsx
@@ -1,16 +1,15 @@
 import React from "react";
 
 import VerticalProgressBar from "riipen-ui/components/VerticalProgressBar";
+import VerticalProgressBarItem from "riipen-ui/components/VerticalProgressBarItem";
 
 export default function Color() {
   return (
-    <VerticalProgressBar
-      progresses={[
-        { color: "positive" },
-        { color: "warning" },
-        { color: "positive" },
-        { color: "default" }
-      ]}
-    />
+    <VerticalProgressBar>
+      <VerticalProgressBarItem color="positive" />
+      <VerticalProgressBarItem color="warning" />
+      <VerticalProgressBarItem color="positive" />
+      <VerticalProgressBarItem color="default" />
+    </VerticalProgressBar>
   );
 }

--- a/packages/riipen-ui-docs/src/pages/components/vertical-progress-bar/Content.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/vertical-progress-bar/Content.jsx
@@ -1,34 +1,24 @@
+import { faChevronRight } from "@fortawesome/free-solid-svg-icons";
 import React from "react";
 
 import VerticalProgressBar from "riipen-ui/components/VerticalProgressBar";
-
-import { faChevronRight } from "@fortawesome/free-solid-svg-icons";
+import VerticalProgressBarItem from "riipen-ui/components/VerticalProgressBarItem";
 
 export default function Content() {
   return (
-    <VerticalProgressBar
-      progresses={[
-        {
-          icon: faChevronRight,
-          color: "positive",
-          children: "content 1"
-        },
-        {
-          icon: faChevronRight,
-          color: "positive",
-          children: "content 2"
-        },
-        {
-          icon: faChevronRight,
-          color: "positive",
-          children: "content 3"
-        },
-        {
-          icon: faChevronRight,
-          color: "positive",
-          children: "content 4"
-        }
-      ]}
-    />
+    <VerticalProgressBar>
+      <VerticalProgressBarItem color="positive" icon={faChevronRight}>
+        content 1
+      </VerticalProgressBarItem>
+      <VerticalProgressBarItem color="warning" icon={faChevronRight}>
+        content 2
+      </VerticalProgressBarItem>
+      <VerticalProgressBarItem color="warning" icon={faChevronRight}>
+        content 3
+      </VerticalProgressBarItem>
+      <VerticalProgressBarItem color="warning" icon={faChevronRight}>
+        content 4
+      </VerticalProgressBarItem>
+    </VerticalProgressBar>
   );
 }

--- a/packages/riipen-ui-docs/src/pages/components/vertical-progress-bar/Icon.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/vertical-progress-bar/Icon.jsx
@@ -1,18 +1,16 @@
+import { faChevronRight, faAtom } from "@fortawesome/free-solid-svg-icons";
 import React from "react";
 
 import VerticalProgressBar from "riipen-ui/components/VerticalProgressBar";
-
-import { faChevronRight, faAtom } from "@fortawesome/free-solid-svg-icons";
+import VerticalProgressBarItem from "riipen-ui/components/VerticalProgressBarItem";
 
 export default function Icon() {
   return (
-    <VerticalProgressBar
-      progresses={[
-        { icon: faAtom, color: "positive" },
-        { icon: faChevronRight, color: "positive" },
-        { icon: faAtom, color: "positive" },
-        { icon: faChevronRight, color: "positive" }
-      ]}
-    />
+    <VerticalProgressBar>
+      <VerticalProgressBarItem color="positive" icon={faAtom} />
+      <VerticalProgressBarItem color="positive" icon={faChevronRight} />
+      <VerticalProgressBarItem color="positive" icon={faAtom} />
+      <VerticalProgressBarItem color="positive" icon={faChevronRight} />
+    </VerticalProgressBar>
   );
 }

--- a/packages/riipen-ui/src/components/VerticalProgressBar.jsx
+++ b/packages/riipen-ui/src/components/VerticalProgressBar.jsx
@@ -5,21 +5,18 @@ import withClasses from "../utils/withClasses";
 
 import Grid from "./Grid";
 import GridItem from "./GridItem";
-import VerticalProgressBarItem from "./VerticalProgressBarItem";
 
-const VerticalProgressBar = ({ progresses }) => {
-  const renderProgress = () => {
-    return progresses.map((progress, index) => (
+const VerticalProgressBar = ({ children, classes }) => (
+  <Grid classes={classes} spacing={0}>
+    {React.Children.map(children, (child, index) => (
       <GridItem key={`progress-${index}`}>
-        <VerticalProgressBarItem
-          progress={{ ...progress, noBar: index >= progresses.length - 1 }}
-        />
+        {index === children.length - 1
+          ? React.cloneElement(child, { bar: false })
+          : child}
       </GridItem>
-    ));
-  };
-
-  return <Grid spacing={0}>{renderProgress()}</Grid>;
-};
+    ))}
+  </Grid>
+);
 
 VerticalProgressBar.propTypes = {
   // external
@@ -27,33 +24,17 @@ VerticalProgressBar.propTypes = {
   /**
    * The progresses to display.
    */
-  progresses: PropTypes.arrayOf(
-    PropTypes.shape({
-      /**
-       * The progress icon.
-       */
-      icon: PropTypes.object,
+  children: PropTypes.node,
 
-      /**
-       * The content to render inside.
-       */
-      children: PropTypes.node,
-
-      /**
-       * The colour of the progress icon.
-       */
-      color: PropTypes.string,
-
-      /**
-       * Whether to not have bar.
-       */
-      noBar: PropTypes.bool
-    })
-  )
+  /**
+   * Additional classes to style with.
+   */
+  classes: PropTypes.array
 };
 
 VerticalProgressBar.defaultProps = {
-  progresses: []
+  children: [],
+  classes: []
 };
 
 export default withClasses(VerticalProgressBar);

--- a/packages/riipen-ui/src/components/VerticalProgressBar.test.jsx
+++ b/packages/riipen-ui/src/components/VerticalProgressBar.test.jsx
@@ -1,0 +1,109 @@
+import { mount } from "enzyme";
+import toJson from "enzyme-to-json";
+import React from "react";
+
+import VerticalProgressBar from "./VerticalProgressBar";
+import VerticalProgressBarItem from "./VerticalProgressBarItem";
+
+describe("<VerticalProgressBar>", () => {
+  it("renders without errors", () => {
+    let error;
+
+    try {
+      mount(<VerticalProgressBar />);
+    } catch (theError) {
+      error = theError;
+    }
+
+    expect(error).toEqual(undefined);
+  });
+
+  it("renders correct snapshot", () => {
+    const wrapper = mount(<VerticalProgressBar />);
+
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  describe("children prop", () => {
+    it("renders given children", () => {
+      const child = <span>this is a child</span>;
+
+      const wrapper = mount(<VerticalProgressBar>{child}</VerticalProgressBar>);
+
+      expect(wrapper.find("VerticalProgressBar").contains(child)).toEqual(true);
+    });
+
+    it("passes bar = false to last child", () => {
+      const children = [
+        <VerticalProgressBarItem key="1" />,
+        <VerticalProgressBarItem key="2" />
+      ];
+
+      const wrapper = mount(
+        <VerticalProgressBar>{children}</VerticalProgressBar>
+      );
+
+      expect(
+        wrapper
+          .find("VerticalProgressBarItem")
+          .at(1)
+          .props().bar
+      ).toBe(false);
+    });
+
+    it("does not pass bar to non-last child", () => {
+      const children = [
+        <VerticalProgressBarItem key="1" />,
+        <VerticalProgressBarItem key="2" />
+      ];
+
+      const wrapper = mount(
+        <VerticalProgressBar>{children}</VerticalProgressBar>
+      );
+
+      expect(
+        wrapper
+          .find("VerticalProgressBarItem")
+          .at(0)
+          .props().bar
+      ).toBe(true);
+    });
+  });
+
+  describe("classes prop", () => {
+    it("applies classes to the root node of VerticalProgressBar", () => {
+      const classes = ["classOne"];
+
+      const wrapper = mount(<VerticalProgressBar classes={classes} />);
+
+      expect(
+        wrapper
+          .find("VerticalProgressBar")
+          .childAt(0)
+          .props().classes
+      ).toContain(classes[0]);
+    });
+
+    it("appends higher order values to classes prop with withClasses decorator", () => {
+      const classes = ["riipen", "riipen-verticalprogressbar"];
+
+      const wrapper = mount(<VerticalProgressBar />);
+
+      expect(
+        wrapper
+          .find("VerticalProgressBar")
+          .props()
+          .classes.sort()
+      ).toEqual(classes.sort());
+    });
+
+    it("gives an error when classes are provided as one string", () => {
+      const classes = "classOne classTwo";
+      const errors = jest.spyOn(console, "error").mockImplementation();
+
+      mount(<VerticalProgressBar classes={classes} />);
+
+      expect(errors).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/riipen-ui/src/components/VerticalProgressBar.test.jsx
+++ b/packages/riipen-ui/src/components/VerticalProgressBar.test.jsx
@@ -30,7 +30,7 @@ describe("<VerticalProgressBar>", () => {
 
       const wrapper = mount(<VerticalProgressBar>{child}</VerticalProgressBar>);
 
-      expect(wrapper.find("VerticalProgressBar").contains(child)).toEqual(true);
+      expect(wrapper.text()).toContain("this is a child");
     });
 
     it("passes bar = false to last child", () => {

--- a/packages/riipen-ui/src/components/VerticalProgressBarItem.jsx
+++ b/packages/riipen-ui/src/components/VerticalProgressBarItem.jsx
@@ -1,10 +1,9 @@
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import clsx from "clsx";
 import React from "react";
 import PropTypes from "prop-types";
 import css from "styled-jsx/css";
 import _JSXStyle from "styled-jsx/style";
-
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import ThemeContext from "../styles/ThemeContext";
 import withClasses from "../utils/withClasses";
@@ -12,7 +11,7 @@ import withClasses from "../utils/withClasses";
 import Grid from "./Grid";
 import GridItem from "./GridItem";
 
-const VerticalProgressBarItem = ({ progress }) => {
+const VerticalProgressBarItem = ({ bar, children, classes, color, icon }) => {
   const theme = React.useContext(ThemeContext);
 
   const getLinkedStyles = () => {
@@ -30,35 +29,29 @@ const VerticalProgressBarItem = ({ progress }) => {
 
   const linkedStyles = getLinkedStyles();
 
-  const iconClasses = [
-    "iconWrapper",
-    progress.color && `${progress.color}`
-  ].filter(Boolean);
-
-  const className = clsx(
-    "progress",
-    progress.color && !progress.noBar && `progress-${progress.color}`,
-    progress.noBar && "progress-none"
-  );
-
   return (
-    <React.Fragment>
-      <div className={className}>
-        <Grid classes={[linkedStyles.className, "wrapper"]} spacing={0}>
-          <GridItem lg={2}>
-            <div className={clsx(iconClasses)}>
-              {!!progress.icon && (
-                <FontAwesomeIcon
-                  className={clsx(linkedStyles.className, "icon")}
-                  size="sm"
-                  icon={progress.icon}
-                />
-              )}
-            </div>
-          </GridItem>
-          <GridItem lg={10}>{progress.children}</GridItem>
-        </Grid>
-      </div>
+    <div
+      className={clsx(
+        "progress",
+        color && bar && `progress-${color}`,
+        !bar && "progress-none",
+        classes
+      )}
+    >
+      <Grid classes={[linkedStyles.className, "wrapper"]} spacing={0}>
+        <GridItem lg={2}>
+          <div className={clsx("iconWrapper", color && `${color}`)}>
+            {!!icon && (
+              <FontAwesomeIcon
+                className={clsx(linkedStyles.className, "icon")}
+                size="sm"
+                icon={icon}
+              />
+            )}
+          </div>
+        </GridItem>
+        <GridItem lg={10}>{children}</GridItem>
+      </Grid>
       <style jsx>{`
         .default {
           background-color: ${theme.palette.grey[300]};
@@ -107,7 +100,7 @@ const VerticalProgressBarItem = ({ progress }) => {
         }
       `}</style>
       {linkedStyles.styles}
-    </React.Fragment>
+    </div>
   );
 };
 
@@ -115,29 +108,34 @@ VerticalProgressBarItem.propTypes = {
   // external
 
   /**
-   * The progress to render.
+   * The content to render inside.
    */
-  progress: PropTypes.shape({
-    /**
-     * The content to render inside.
-     */
-    children: PropTypes.node,
+  children: PropTypes.node,
 
-    /**
-     * The colour of the progress icon.
-     */
-    color: PropTypes.oneOf(["positive", "warning", "default"]),
+  /**
+   * Additional classes to style with.
+   */
+  classes: PropTypes.array,
 
-    /**
-     * The progress icon.
-     */
-    icon: PropTypes.object,
+  /**
+   * The colour of the progress icon.
+   */
+  color: PropTypes.oneOf(["positive", "warning", "default"]),
 
-    /**
-     * Whether to not have bar.
-     */
-    noBar: PropTypes.bool
-  }).isRequired
+  /**
+   * The progress icon.
+   */
+  icon: PropTypes.object,
+
+  /**
+   * Whether to not have bar.
+   */
+  bar: PropTypes.bool
+};
+
+VerticalProgressBarItem.defaultProps = {
+  bar: true,
+  classes: []
 };
 
 export default withClasses(VerticalProgressBarItem);

--- a/packages/riipen-ui/src/components/VerticalProgressBarItem.jsx
+++ b/packages/riipen-ui/src/components/VerticalProgressBarItem.jsx
@@ -20,10 +20,6 @@ const VerticalProgressBarItem = ({ bar, children, classes, color, icon }) => {
         color: ${theme.palette.common.white};
         z-index: ${theme.zIndex.low};
       }
-
-      .wrapper {
-        margin-top: ${theme.spacing(-6)}px;
-      }
     `;
   };
 
@@ -70,7 +66,6 @@ const VerticalProgressBarItem = ({ bar, children, classes, color, icon }) => {
         .progress {
           border-left: 8px solid var(--border-color);
           margin-left: ${theme.spacing(3)}px;
-          padding: ${theme.spacing(4)}px 0;
         }
 
         /* Progress bar colors. */
@@ -99,7 +94,7 @@ const VerticalProgressBarItem = ({ bar, children, classes, color, icon }) => {
           margin-bottom: ${theme.spacing(7)}px;
           margin-left: -16px;
           margin-right: ${theme.spacing(5)}px;
-          margin-top: ${theme.spacing(2) - 1}px;
+          margin-top: -1px;
           width: 24px;
         }
       `}</style>

--- a/packages/riipen-ui/src/components/VerticalProgressBarItem.jsx
+++ b/packages/riipen-ui/src/components/VerticalProgressBarItem.jsx
@@ -39,7 +39,7 @@ const VerticalProgressBarItem = ({ bar, children, classes, color, icon }) => {
       )}
     >
       <Grid classes={[linkedStyles.className, "wrapper"]} spacing={0}>
-        <GridItem lg={2}>
+        <GridItem lg="auto">
           <div className={clsx("iconWrapper", color && `${color}`)}>
             {!!icon && (
               <FontAwesomeIcon
@@ -50,7 +50,9 @@ const VerticalProgressBarItem = ({ bar, children, classes, color, icon }) => {
             )}
           </div>
         </GridItem>
-        <GridItem lg={10}>{children}</GridItem>
+        <GridItem flexGrow={1} flexShrink={1} lg={10}>
+          {children}
+        </GridItem>
       </Grid>
       <style jsx>{`
         .default {
@@ -94,8 +96,10 @@ const VerticalProgressBarItem = ({ bar, children, classes, color, icon }) => {
           display: flex;
           height: 24px;
           justify-content: center;
-          margin: ${theme.spacing(2)}px 0 ${theme.spacing(7)}px -23px;
-          padding: 7px;
+          margin-bottom: ${theme.spacing(7)}px;
+          margin-left: -16px;
+          margin-right: ${theme.spacing(5)}px;
+          margin-top: ${theme.spacing(2) - 1}px;
           width: 24px;
         }
       `}</style>

--- a/packages/riipen-ui/src/components/VerticalProgressBarItem.test.jsx
+++ b/packages/riipen-ui/src/components/VerticalProgressBarItem.test.jsx
@@ -31,9 +31,7 @@ describe("<VerticalProgressBarItem>", () => {
         <VerticalProgressBarItem>{child}</VerticalProgressBarItem>
       );
 
-      expect(wrapper.find("VerticalProgressBarItem").contains(child)).toEqual(
-        true
-      );
+      expect(wrapper.text()).toContain("this is a child");
     });
   });
 

--- a/packages/riipen-ui/src/components/VerticalProgressBarItem.test.jsx
+++ b/packages/riipen-ui/src/components/VerticalProgressBarItem.test.jsx
@@ -1,0 +1,115 @@
+import { mount } from "enzyme";
+import toJson from "enzyme-to-json";
+import React from "react";
+
+import VerticalProgressBarItem from "./VerticalProgressBarItem";
+
+describe("<VerticalProgressBarItem>", () => {
+  it("renders without errors", () => {
+    let error;
+
+    try {
+      mount(<VerticalProgressBarItem />);
+    } catch (theError) {
+      error = theError;
+    }
+
+    expect(error).toEqual(undefined);
+  });
+
+  it("renders correct snapshot", () => {
+    const wrapper = mount(<VerticalProgressBarItem />);
+
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  describe("children prop", () => {
+    it("renders given children", () => {
+      const child = <span>this is a child</span>;
+
+      const wrapper = mount(
+        <VerticalProgressBarItem>{child}</VerticalProgressBarItem>
+      );
+
+      expect(wrapper.find("VerticalProgressBarItem").contains(child)).toEqual(
+        true
+      );
+    });
+  });
+
+  describe("classes prop", () => {
+    it("applies classes to the root node of VerticalProgressBarItem", () => {
+      const classes = ["classOne"];
+
+      const wrapper = mount(<VerticalProgressBarItem classes={classes} />);
+
+      expect(
+        wrapper
+          .find("VerticalProgressBarItem")
+          .childAt(0)
+          .hasClass(classes[0])
+      ).toEqual(true);
+    });
+
+    it("appends higher order values to classes prop with withClasses decorator", () => {
+      const classes = ["riipen", "riipen-verticalprogressbaritem"];
+
+      const wrapper = mount(<VerticalProgressBarItem />);
+
+      expect(
+        wrapper
+          .find("VerticalProgressBarItem")
+          .props()
+          .classes.sort()
+      ).toEqual(classes.sort());
+    });
+
+    it("gives an error when classes are provided as one string", () => {
+      const classes = "classOne classTwo";
+      const errors = jest.spyOn(console, "error").mockImplementation();
+
+      mount(<VerticalProgressBarItem classes={classes} />);
+
+      expect(errors).toHaveBeenCalled();
+    });
+  });
+
+  describe("color prop", () => {
+    it("renders given color", () => {
+      const color = "positive";
+      const wrapper = mount(<VerticalProgressBarItem color={color} />);
+
+      expect(wrapper.find(".positive")).toHaveLength(1);
+    });
+  });
+
+  describe("icon prop", () => {
+    it("renders an icon", () => {
+      const icon = <span />;
+      const wrapper = mount(<VerticalProgressBarItem icon={icon} />);
+
+      expect(wrapper.find("FontAwesomeIcon")).toHaveLength(1);
+    });
+
+    it("does not render an icon if not provided", () => {
+      const wrapper = mount(<VerticalProgressBarItem />);
+
+      expect(wrapper.find("FontAwesomeIcon")).toHaveLength(0);
+    });
+  });
+
+  describe("bar prop", () => {
+    it("passes correct class when bar and color provided", () => {
+      const color = "positive";
+      const wrapper = mount(<VerticalProgressBarItem color={color} />);
+
+      expect(wrapper.find(".progress-positive")).toHaveLength(1);
+    });
+
+    it("has correct classes when bar ", () => {
+      const wrapper = mount(<VerticalProgressBarItem bar={false} />);
+
+      expect(wrapper.find(".progress-none")).toHaveLength(1);
+    });
+  });
+});

--- a/packages/riipen-ui/src/components/__snapshots__/VerticalProgressBar.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/VerticalProgressBar.test.jsx.snap
@@ -1,0 +1,62 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<VerticalProgressBar> renders correct snapshot 1`] = `
+<withClasses(VerticalProgressBar)>
+  <VerticalProgressBar
+    classes={
+      Array [
+        "riipen",
+        "riipen-verticalprogressbar",
+      ]
+    }
+  >
+    <withClasses(Grid)
+      classes={
+        Array [
+          "riipen",
+          "riipen-verticalprogressbar",
+        ]
+      }
+      spacing={0}
+    >
+      <Grid
+        alignItems="flex-start"
+        classes={
+          Array [
+            "riipen",
+            "riipen-grid",
+            "riipen",
+            "riipen-verticalprogressbar",
+          ]
+        }
+        flexDirection="row"
+        flexGrow={1}
+        flexShrink={1}
+        flexWrap="wrap"
+        justifyContent="flex-start"
+        onResize={[Function]}
+        spacing={0}
+      >
+        <div
+          className="jsx-2773517404 riipen riipen-grid riipen riipen-verticalprogressbar md"
+        />
+        <JSXStyle
+          dynamic={
+            Array [
+              "flex-start",
+              "row",
+              1,
+              1,
+              "wrap",
+              "flex-start",
+              0,
+              0,
+            ]
+          }
+          id="3466573101"
+        />
+      </Grid>
+    </withClasses(Grid)>
+  </VerticalProgressBar>
+</withClasses(VerticalProgressBar)>
+`;

--- a/packages/riipen-ui/src/components/__snapshots__/VerticalProgressBarItem.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/VerticalProgressBarItem.test.jsx.snap
@@ -12,12 +12,12 @@ exports[`<VerticalProgressBarItem> renders correct snapshot 1`] = `
     }
   >
     <div
-      className="jsx-4120898643 progress riipen riipen-verticalprogressbaritem"
+      className="jsx-1821936519 progress riipen riipen-verticalprogressbaritem"
     >
       <withClasses(Grid)
         classes={
           Array [
-            "jsx-2412793688",
+            "jsx-358841745",
             "wrapper",
           ]
         }
@@ -29,7 +29,7 @@ exports[`<VerticalProgressBarItem> renders correct snapshot 1`] = `
             Array [
               "riipen",
               "riipen-grid",
-              "jsx-2412793688",
+              "jsx-358841745",
               "wrapper",
             ]
           }
@@ -42,7 +42,7 @@ exports[`<VerticalProgressBarItem> renders correct snapshot 1`] = `
           spacing={0}
         >
           <div
-            className="jsx-2773517404 riipen riipen-grid jsx-2412793688 wrapper md"
+            className="jsx-2773517404 riipen riipen-grid jsx-358841745 wrapper md"
           >
             <withClasses(GridItem)
               key=".0"
@@ -71,7 +71,7 @@ exports[`<VerticalProgressBarItem> renders correct snapshot 1`] = `
                   className="jsx-2183797102 riipen riipen-griditem lg"
                 >
                   <div
-                    className="jsx-4120898643 iconWrapper"
+                    className="jsx-1821936519 iconWrapper"
                   />
                 </div>
                 <JSXStyle
@@ -165,26 +165,23 @@ exports[`<VerticalProgressBarItem> renders correct snapshot 1`] = `
             "#4cc88d",
             "#febb46",
             15,
-            20,
             "#dddddd",
             "#4cc88d",
             "#febb46",
             35,
             25,
-            9,
           ]
         }
-        id="32634603"
+        id="3229497486"
       />
       <JSXStyle
         dynamic={
           Array [
             "#fff",
             2,
-            -30,
           ]
         }
-        id="2622978946"
+        id="3174789173"
       />
     </div>
   </VerticalProgressBarItem>

--- a/packages/riipen-ui/src/components/__snapshots__/VerticalProgressBarItem.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/VerticalProgressBarItem.test.jsx.snap
@@ -1,0 +1,189 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<VerticalProgressBarItem> renders correct snapshot 1`] = `
+<withClasses(VerticalProgressBarItem)>
+  <VerticalProgressBarItem
+    bar={true}
+    classes={
+      Array [
+        "riipen",
+        "riipen-verticalprogressbaritem",
+      ]
+    }
+  >
+    <div
+      className="jsx-3958355838 progress riipen riipen-verticalprogressbaritem"
+    >
+      <withClasses(Grid)
+        classes={
+          Array [
+            "jsx-2412793688",
+            "wrapper",
+          ]
+        }
+        spacing={0}
+      >
+        <Grid
+          alignItems="flex-start"
+          classes={
+            Array [
+              "riipen",
+              "riipen-grid",
+              "jsx-2412793688",
+              "wrapper",
+            ]
+          }
+          flexDirection="row"
+          flexGrow={1}
+          flexShrink={1}
+          flexWrap="wrap"
+          justifyContent="flex-start"
+          onResize={[Function]}
+          spacing={0}
+        >
+          <div
+            className="jsx-2773517404 riipen riipen-grid jsx-2412793688 wrapper md"
+          >
+            <withClasses(GridItem)
+              key=".0"
+              lg={2}
+              size="md"
+              spacing={0}
+            >
+              <GridItem
+                alignItems="stretch"
+                classes={
+                  Array [
+                    "riipen",
+                    "riipen-griditem",
+                  ]
+                }
+                flexDirection="column"
+                flexGrow={0}
+                flexShrink={0}
+                flexWrap="wrap"
+                justifyContent="flex-start"
+                lg={2}
+                size="md"
+                spacing={0}
+              >
+                <div
+                  className="jsx-3535199865 riipen riipen-griditem lg"
+                >
+                  <div
+                    className="jsx-3958355838 iconWrapper"
+                  />
+                </div>
+                <JSXStyle
+                  dynamic={
+                    Array [
+                      "stretch",
+                      "flex",
+                      "16.666666666666664%",
+                      "column",
+                      0,
+                      0,
+                      "wrap",
+                      "flex-start",
+                      0,
+                      0,
+                    ]
+                  }
+                  id="1025619962"
+                />
+              </GridItem>
+            </withClasses(GridItem)>
+            <withClasses(GridItem)
+              key=".1"
+              lg={10}
+              size="md"
+              spacing={0}
+            >
+              <GridItem
+                alignItems="stretch"
+                classes={
+                  Array [
+                    "riipen",
+                    "riipen-griditem",
+                  ]
+                }
+                flexDirection="column"
+                flexGrow={0}
+                flexShrink={0}
+                flexWrap="wrap"
+                justifyContent="flex-start"
+                lg={10}
+                size="md"
+                spacing={0}
+              >
+                <div
+                  className="jsx-2265208582 riipen riipen-griditem lg"
+                />
+                <JSXStyle
+                  dynamic={
+                    Array [
+                      "stretch",
+                      "flex",
+                      "83.33333333333334%",
+                      "column",
+                      0,
+                      0,
+                      "wrap",
+                      "flex-start",
+                      0,
+                      0,
+                    ]
+                  }
+                  id="1025619962"
+                />
+              </GridItem>
+            </withClasses(GridItem)>
+          </div>
+          <JSXStyle
+            dynamic={
+              Array [
+                "flex-start",
+                "row",
+                1,
+                1,
+                "wrap",
+                "flex-start",
+                0,
+                0,
+              ]
+            }
+            id="3466573101"
+          />
+        </Grid>
+      </withClasses(Grid)>
+      <JSXStyle
+        dynamic={
+          Array [
+            "#dddddd",
+            "#4cc88d",
+            "#febb46",
+            15,
+            20,
+            "#dddddd",
+            "#4cc88d",
+            "#febb46",
+            10,
+            35,
+          ]
+        }
+        id="248956935"
+      />
+      <JSXStyle
+        dynamic={
+          Array [
+            "#fff",
+            2,
+            -30,
+          ]
+        }
+        id="2622978946"
+      />
+    </div>
+  </VerticalProgressBarItem>
+</withClasses(VerticalProgressBarItem)>
+`;

--- a/packages/riipen-ui/src/components/__snapshots__/VerticalProgressBarItem.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/VerticalProgressBarItem.test.jsx.snap
@@ -12,7 +12,7 @@ exports[`<VerticalProgressBarItem> renders correct snapshot 1`] = `
     }
   >
     <div
-      className="jsx-3958355838 progress riipen riipen-verticalprogressbaritem"
+      className="jsx-4120898643 progress riipen riipen-verticalprogressbaritem"
     >
       <withClasses(Grid)
         classes={
@@ -46,7 +46,7 @@ exports[`<VerticalProgressBarItem> renders correct snapshot 1`] = `
           >
             <withClasses(GridItem)
               key=".0"
-              lg={2}
+              lg="auto"
               size="md"
               spacing={0}
             >
@@ -63,15 +63,15 @@ exports[`<VerticalProgressBarItem> renders correct snapshot 1`] = `
                 flexShrink={0}
                 flexWrap="wrap"
                 justifyContent="flex-start"
-                lg={2}
+                lg="auto"
                 size="md"
                 spacing={0}
               >
                 <div
-                  className="jsx-3535199865 riipen riipen-griditem lg"
+                  className="jsx-2183797102 riipen riipen-griditem lg"
                 >
                   <div
-                    className="jsx-3958355838 iconWrapper"
+                    className="jsx-4120898643 iconWrapper"
                   />
                 </div>
                 <JSXStyle
@@ -79,7 +79,7 @@ exports[`<VerticalProgressBarItem> renders correct snapshot 1`] = `
                     Array [
                       "stretch",
                       "flex",
-                      "16.666666666666664%",
+                      "auto",
                       "column",
                       0,
                       0,
@@ -94,6 +94,8 @@ exports[`<VerticalProgressBarItem> renders correct snapshot 1`] = `
               </GridItem>
             </withClasses(GridItem)>
             <withClasses(GridItem)
+              flexGrow={1}
+              flexShrink={1}
               key=".1"
               lg={10}
               size="md"
@@ -108,8 +110,8 @@ exports[`<VerticalProgressBarItem> renders correct snapshot 1`] = `
                   ]
                 }
                 flexDirection="column"
-                flexGrow={0}
-                flexShrink={0}
+                flexGrow={1}
+                flexShrink={1}
                 flexWrap="wrap"
                 justifyContent="flex-start"
                 lg={10}
@@ -117,7 +119,7 @@ exports[`<VerticalProgressBarItem> renders correct snapshot 1`] = `
                 spacing={0}
               >
                 <div
-                  className="jsx-2265208582 riipen riipen-griditem lg"
+                  className="jsx-4088224518 riipen riipen-griditem lg"
                 />
                 <JSXStyle
                   dynamic={
@@ -126,8 +128,8 @@ exports[`<VerticalProgressBarItem> renders correct snapshot 1`] = `
                       "flex",
                       "83.33333333333334%",
                       "column",
-                      0,
-                      0,
+                      1,
+                      1,
                       "wrap",
                       "flex-start",
                       0,
@@ -167,11 +169,12 @@ exports[`<VerticalProgressBarItem> renders correct snapshot 1`] = `
             "#dddddd",
             "#4cc88d",
             "#febb46",
-            10,
             35,
+            25,
+            9,
           ]
         }
-        id="248956935"
+        id="32634603"
       />
       <JSXStyle
         dynamic={


### PR DESCRIPTION
## Description
Update VerticalProgressBar to use inversion of control and accept VerticalProgressBarItems as children, rather than using the `progresses` prop.
Add unit tests for VerticalProgressBar/VerticalProgressBarItem.
Some minor clean up.
Small styling edits to make the icon circle slightly smaller, and decrease the margin from the icons to the content.

## Screenshots
![Screenshot 2021-06-15 at 18-20-40 Vertical Progress Bar Riipen UI](https://user-images.githubusercontent.com/10818279/122143530-7d2a9380-ce06-11eb-94d1-41faaef180fc.png)

## Where to Start
VerticalProgressBar
