### PR TITLE
Make label prop of type node

### DIFF
--- a/packages/riipen-ui/src/components/Input.jsx
+++ b/packages/riipen-ui/src/components/Input.jsx
@@ -272,7 +272,7 @@ Input.propTypes = {
   /**
    * Label text to display for the input.
    */
-  label: PropTypes.string,
+  label: PropTypes.node,
 
   /**
    * Props passed through to the InputLabel.


### PR DESCRIPTION
## Description
Update label prop type to be node.

## Where to Start
 packages/riipen-ui/src/components/Input.jsx