### PR TITLE
[PLT-8224] Add tooltip prop to RadioGroup

### DIFF
--- a/packages/riipen-ui/src/components/InputLabel.jsx
+++ b/packages/riipen-ui/src/components/InputLabel.jsx
@@ -17,6 +17,7 @@ const InputLabel = ({
   hint,
   required,
   theme,
+  tooltip,
   variant,
   ...other
 }) => {
@@ -36,6 +37,7 @@ const InputLabel = ({
           >
             {children}
             {required && " *"}
+            <span className="tooltip">{tooltip}</span>
           </Typography>
         </label>
       )}
@@ -44,6 +46,10 @@ const InputLabel = ({
         label {
           display: inline-block;
           margin-bottom: ${theme.spacing(marginBottom)}px;
+        }
+
+        .tooltip {
+          margin-left: ${theme.spacing(1)}px;
         }
       `}</style>
     </React.Fragment>
@@ -64,12 +70,12 @@ InputLabel.propTypes = {
   classes: PropTypes.array,
 
   /**
-   * Color of the label text. Passed through to Typopgraphy
+   * Color of the label text. Passed through to Typopgraphy.
    */
   color: PropTypes.string,
 
   /**
-   * Font weight for the label text. Passed through to Typopgraphy
+   * Font weight for the label text. Passed through to Typopgraphy.
    */
   fontWeight: PropTypes.string,
 
@@ -85,12 +91,17 @@ InputLabel.propTypes = {
 
   /**
    * @ignore
-   * The theme context object
+   * The theme context object.
    */
   theme: PropTypes.object,
 
   /**
-   * Variant for the label text. Passed through to Typopgraphy
+   * Any tooltip info to display beside the label.
+   */
+  tooltip: PropTypes.node,
+
+  /**
+   * Variant for the label text. Passed through to Typopgraphy.
    */
   variant: PropTypes.string
 };

--- a/packages/riipen-ui/src/components/InputLabel.jsx
+++ b/packages/riipen-ui/src/components/InputLabel.jsx
@@ -17,7 +17,7 @@ const InputLabel = ({
   hint,
   required,
   theme,
-  tooltip,
+  suffix,
   variant,
   ...other
 }) => {
@@ -37,7 +37,7 @@ const InputLabel = ({
           >
             {children}
             {required && " *"}
-            <span className="tooltip">{tooltip}</span>
+            <span className="suffix">{suffix}</span>
           </Typography>
         </label>
       )}
@@ -48,7 +48,7 @@ const InputLabel = ({
           margin-bottom: ${theme.spacing(marginBottom)}px;
         }
 
-        .tooltip {
+        .suffix {
           margin-left: ${theme.spacing(1)}px;
         }
       `}</style>
@@ -96,9 +96,9 @@ InputLabel.propTypes = {
   theme: PropTypes.object,
 
   /**
-   * Any tooltip info to display beside the label.
+   * Any suffix to display beside the label.
    */
-  tooltip: PropTypes.node,
+  suffix: PropTypes.node,
 
   /**
    * Variant for the label text. Passed through to Typopgraphy.

--- a/packages/riipen-ui/src/components/InputLabel.test.jsx
+++ b/packages/riipen-ui/src/components/InputLabel.test.jsx
@@ -165,18 +165,18 @@ describe("<InputLabel>", () => {
     });
   });
 
-  describe("tooltip prop", () => {
-    it("renders tooltip inside the label and Typography element", () => {
-      const tooltip = <span>Tooltip</span>;
+  describe("suffix prop", () => {
+    it("renders suffix inside the label and Typography element", () => {
+      const suffix = <span>Test</span>;
 
-      const wrapper = mount(<InputLabel>{tooltip}</InputLabel>);
+      const wrapper = mount(<InputLabel>{suffix}</InputLabel>);
 
       expect(
         wrapper
           .find("InputLabel")
           .find("label")
           .find("Typography")
-          .contains(tooltip)
+          .contains(suffix)
       ).toEqual(true);
     });
   });

--- a/packages/riipen-ui/src/components/InputLabel.test.jsx
+++ b/packages/riipen-ui/src/components/InputLabel.test.jsx
@@ -165,6 +165,22 @@ describe("<InputLabel>", () => {
     });
   });
 
+  describe("tooltip prop", () => {
+    it("renders tooltip inside the label and Typography element", () => {
+      const tooltip = <span>Tooltip</span>;
+
+      const wrapper = mount(<InputLabel>{tooltip}</InputLabel>);
+
+      expect(
+        wrapper
+          .find("InputLabel")
+          .find("label")
+          .find("Typography")
+          .contains(tooltip)
+      ).toEqual(true);
+    });
+  });
+
   describe("fontWeight prop", () => {
     it("Passes fontWeight to the underlying typography", () => {
       const fontWeight = "bold";

--- a/packages/riipen-ui/src/components/RadioGroup.jsx
+++ b/packages/riipen-ui/src/components/RadioGroup.jsx
@@ -15,7 +15,7 @@ const RadioGroup = ({
   labelProps,
   onChange,
   required,
-  tooltip,
+  suffix,
   value,
   warning,
   ...other
@@ -40,13 +40,13 @@ const RadioGroup = ({
   return (
     <React.Fragment>
       <fieldset>
-        {(label || hint || tooltip) && (
+        {(label || hint || suffix) && (
           <InputLabel
             hint={hint}
             htmlFor={other.name}
             required={required}
             {...labelProps}
-            tooltip={tooltip}
+            suffix={suffix}
           >
             {label}
           </InputLabel>
@@ -114,9 +114,9 @@ RadioGroup.propTypes = {
   required: PropTypes.bool,
 
   /**
-   * Any tooltip info to display beside the label.
+   * Any suffix to display beside the label.
    */
-  tooltip: PropTypes.node,
+  suffix: PropTypes.node,
 
   /**
    * The value of the selected radio button.

--- a/packages/riipen-ui/src/components/RadioGroup.jsx
+++ b/packages/riipen-ui/src/components/RadioGroup.jsx
@@ -15,6 +15,7 @@ const RadioGroup = ({
   labelProps,
   onChange,
   required,
+  tooltip,
   value,
   warning,
   ...other
@@ -39,12 +40,13 @@ const RadioGroup = ({
   return (
     <React.Fragment>
       <fieldset>
-        {(label || hint) && (
+        {(label || hint || tooltip) && (
           <InputLabel
             hint={hint}
             htmlFor={other.name}
             required={required}
             {...labelProps}
+            tooltip={tooltip}
           >
             {label}
           </InputLabel>
@@ -94,7 +96,7 @@ RadioGroup.propTypes = {
   label: PropTypes.node,
 
   /**
-   * Any props to pass through to the InputLabel
+   * Any props to pass through to the InputLabel.
    */
   labelProps: PropTypes.object,
 
@@ -112,7 +114,12 @@ RadioGroup.propTypes = {
   required: PropTypes.bool,
 
   /**
-   * The value of the selected radio button
+   * Any tooltip info to display beside the label.
+   */
+  tooltip: PropTypes.node,
+
+  /**
+   * The value of the selected radio button.
    */
   value: PropTypes.any,
 

--- a/packages/riipen-ui/src/components/RadioGroup.jsx
+++ b/packages/riipen-ui/src/components/RadioGroup.jsx
@@ -45,8 +45,8 @@ const RadioGroup = ({
             hint={hint}
             htmlFor={other.name}
             required={required}
-            {...labelProps}
             suffix={suffix}
+            {...labelProps}
           >
             {label}
           </InputLabel>

--- a/packages/riipen-ui/src/components/RadioGroup.test.jsx
+++ b/packages/riipen-ui/src/components/RadioGroup.test.jsx
@@ -141,13 +141,13 @@ describe("<RadioGroup>", () => {
     });
   });
 
-  describe("tooltip prop", () => {
-    it("passes tooltip prop to InputLabel", () => {
-      const tooltip = <span>"Tooltip"</span>;
+  describe("suffix prop", () => {
+    it("passes suffix prop to InputLabel", () => {
+      const suffix = <span>"Test"</span>;
 
-      const wrapper = mount(<RadioGroup tooltip={tooltip} />);
+      const wrapper = mount(<RadioGroup suffix={suffix} />);
 
-      expect(wrapper.find("InputLabel").props().tooltip).toEqual(tooltip);
+      expect(wrapper.find("InputLabel").props().suffix).toEqual(suffix);
     });
   });
 

--- a/packages/riipen-ui/src/components/RadioGroup.test.jsx
+++ b/packages/riipen-ui/src/components/RadioGroup.test.jsx
@@ -141,6 +141,16 @@ describe("<RadioGroup>", () => {
     });
   });
 
+  describe("tooltip prop", () => {
+    it("passes tooltip prop to InputLabel", () => {
+      const tooltip = <span>"Tooltip"</span>;
+
+      const wrapper = mount(<RadioGroup tooltip={tooltip} />);
+
+      expect(wrapper.find("InputLabel").props().tooltip).toEqual(tooltip);
+    });
+  });
+
   describe("value prop", () => {
     it("sets the childs checked prop according to the value", () => {
       const child = <Radio value="one" id="one" />;

--- a/packages/riipen-ui/src/components/__snapshots__/InputLabel.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/InputLabel.test.jsx.snap
@@ -440,9 +440,10 @@ exports[`<InputLabel> renders correct snapshot 1`] = `
         dynamic={
           Array [
             15,
+            5,
           ]
         }
-        id="517714963"
+        id="803353257"
       />
     </InputLabel>
   </withClasses(InputLabel)>

--- a/packages/riipen-ui/src/components/__snapshots__/InputLabel.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/InputLabel.test.jsx.snap
@@ -443,7 +443,7 @@ exports[`<InputLabel> renders correct snapshot 1`] = `
             5,
           ]
         }
-        id="803353257"
+        id="3813465581"
       />
     </InputLabel>
   </withClasses(InputLabel)>


### PR DESCRIPTION
## Description
We are updating the Project Wizard to include descriptive Tooltips. Similar to how `FormGroup` was updated in `platform-web` to include the tooltip as a prop, we should update RadioGroup so it can pass a tooltip node.

Related PR: [Project Library Tooltips](https://github.com/riipen/platform-web/pull/4609)

## Screenshots
Added in text to show placement of where the tooltip would go

<img width="409" alt="Screen Shot 2021-08-11 at 5 34 44 PM" src="https://user-images.githubusercontent.com/61811702/129140700-dc1bcfb1-df87-44b9-b8ef-588daa0798ed.png">
