### PR TITLE
[PLT-8331] Update typography sizes and add mobile sizes

### DIFF
--- a/packages/riipen-ui/src/components/Typography.jsx
+++ b/packages/riipen-ui/src/components/Typography.jsx
@@ -77,6 +77,11 @@ class Typography extends React.Component {
     gutter: PropTypes.bool,
 
     /**
+     * Screen size to render font from desktop to mobile.
+     */
+    mobileBreakpoint: PropTypes.oneOf(["xs", "sm", "md", "lg", "xl"]),
+
+    /**
      * Set the text-align on the component.
      */
     textAlign: PropTypes.oneOf([
@@ -119,6 +124,7 @@ class Typography extends React.Component {
     color: "inherit",
     display: "initial",
     gutter: false,
+    mobileBreakpoint: "sm",
     textAlign: "inherit",
     textTransform: "inherit",
     variant: "body1"
@@ -135,6 +141,7 @@ class Typography extends React.Component {
       display,
       fontWeight,
       gutter,
+      mobileBreakpoint,
       textAlign,
       textTransform,
       variant
@@ -148,6 +155,7 @@ class Typography extends React.Component {
       display,
       fontWeight,
       gutter ? "gutter" : null,
+      mobileBreakpoint ? "mobile" : null,
       variant,
       `align-${textAlign}`,
       `transform-${textTransform}`,
@@ -317,6 +325,41 @@ class Typography extends React.Component {
           }
           .transform-lowercase {
             text-transform: lowercase;
+          }
+
+          @media (max-width: ${theme.breakpoints[mobileBreakpoint]}px) {
+            .body1.mobile {
+              font-size: ${theme.typography.body1.mobile.fontSize};
+              line-height: ${theme.typography.body1.mobile.lineHeight};
+            }
+            .body2.mobile {
+              font-size: ${theme.typography.body2.mobile.fontSize};
+              line-height: ${theme.typography.body2.mobile.lineHeight};
+            }
+            .body3.mobile {
+              font-size: ${theme.typography.body3.mobile.fontSize};
+              line-height: ${theme.typography.body3.mobile.lineHeight};
+            }
+            .h1.mobile {
+              font-size: ${theme.typography.h1.mobile.fontSize};
+              line-height: ${theme.typography.h1.mobile.lineHeight};
+            }
+            .h2.mobile {
+              font-size: ${theme.typography.h2.mobile.fontSize};
+              line-height: ${theme.typography.h2.mobile.lineHeight};
+            }
+            .h3.mobile {
+              font-size: ${theme.typography.h3.mobile.fontSize};
+              line-height: ${theme.typography.h3.mobile.lineHeight};
+            }
+            .h4.mobile {
+              font-size: ${theme.typography.h4.mobile.fontSize};
+              line-height: ${theme.typography.h4.mobile.lineHeight};
+            }
+            .h5.mobile {
+              font-size: ${theme.typography.h5.mobile.fontSize};
+              line-height: ${theme.typography.h5.mobile.lineHeight};
+            }
           }
         `}</style>
       </>

--- a/packages/riipen-ui/src/components/__snapshots__/Badge.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Badge.test.jsx.snap
@@ -24,10 +24,10 @@ exports[`<Badge> renders correct snapshot 1`] = `
     variant="standard"
   >
     <span
-      className="jsx-2728802926 root"
+      className="jsx-2482181288 root"
     >
       <span
-        className="jsx-2728802926 badge hidden top-right-rectangle primary standard medium riipen riipen-badge"
+        className="jsx-2482181288 badge hidden top-right-rectangle primary standard medium riipen riipen-badge"
       />
     </span>
     <JSXStyle
@@ -37,9 +37,9 @@ exports[`<Badge> renders correct snapshot 1`] = `
           "#373737",
           "Roboto, Helvetica, Arial, sans-serif",
           500,
-          "10px",
-          "14px",
           "12px",
+          "16px",
+          "14px",
           20,
           20,
           10,

--- a/packages/riipen-ui/src/components/__snapshots__/Breadcrumbs.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Breadcrumbs.test.jsx.snap
@@ -26,12 +26,13 @@ exports[`<Breadcrumbs> renders correct snapshot 1`] = `
         component="nav"
         display="initial"
         gutter={false}
+        mobileBreakpoint="sm"
         textAlign="inherit"
         textTransform="inherit"
         variant="body1"
       >
         <nav
-          className="jsx-1194261709 root color-inherit initial body1 align-inherit transform-inherit riipen riipen-typography"
+          className="jsx-2087479458 root color-inherit initial mobile body1 align-inherit transform-inherit riipen riipen-typography"
         >
           <ol
             className="jsx-2183045356 riipen riipen-breadcrumbs"
@@ -52,20 +53,20 @@ exports[`<Breadcrumbs> renders correct snapshot 1`] = `
               "#424242",
               "Roboto, Helvetica, Arial, sans-serif",
               400,
-              "14px",
-              "20px",
+              "16px",
+              "24px",
               "0.00938em",
               "#424242",
               "Roboto, Helvetica, Arial, sans-serif",
               400,
-              "12px",
-              "17px",
+              "14px",
+              "20px",
               "0.01071em",
               "#424242",
               "Roboto, Helvetica, Arial, sans-serif",
               400,
-              "10px",
-              "14px",
+              "12px",
+              "16px",
               "0.01071em",
               "#373737",
               "Roboto, Helvetica, Arial, sans-serif",
@@ -77,7 +78,7 @@ exports[`<Breadcrumbs> renders correct snapshot 1`] = `
               "Roboto, Helvetica, Arial, sans-serif",
               500,
               "30px",
-              "42px",
+              "44px",
               "-0.00833em",
               "#373737",
               "Roboto, Helvetica, Arial, sans-serif",
@@ -89,13 +90,13 @@ exports[`<Breadcrumbs> renders correct snapshot 1`] = `
               "Roboto, Helvetica, Arial, sans-serif",
               400,
               "20px",
-              "30px",
+              "28px",
               "-0.00735em",
               "#373737",
               "Roboto, Helvetica, Arial, sans-serif",
               400,
               "16px",
-              "23px",
+              "24px",
               "0rem",
               "#000",
               "#cccbcb",
@@ -114,9 +115,26 @@ exports[`<Breadcrumbs> renders correct snapshot 1`] = `
               300,
               500,
               400,
+              600,
+              "14px",
+              "20px",
+              "12px",
+              "16px",
+              "11px",
+              "16px",
+              "30px",
+              "44px",
+              "22px",
+              "32px",
+              "18px",
+              "28px",
+              "16px",
+              "24px",
+              "14px",
+              "20px",
             ]
           }
-          id="3194901921"
+          id="585098619"
         />
       </Typography>
     </withClasses(Typography)>

--- a/packages/riipen-ui/src/components/__snapshots__/Button.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Button.test.jsx.snap
@@ -138,31 +138,43 @@ exports[`<Button> renders correct snapshot 1`] = `
         "typography": Object {
           "body1": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "14px",
+            "fontSize": "16px",
             "fontWeight": 400,
             "letterSpacing": "0.00938em",
-            "lineHeight": "20px",
+            "lineHeight": "24px",
+            "mobile": Object {
+              "fontSize": "14px",
+              "lineHeight": "20px",
+            },
           },
           "body2": Object {
+            "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
+            "fontSize": "14px",
+            "fontWeight": 400,
+            "letterSpacing": "0.01071em",
+            "lineHeight": "20px",
+            "mobile": Object {
+              "fontSize": "12px",
+              "lineHeight": "16px",
+            },
+          },
+          "body3": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "12px",
             "fontWeight": 400,
             "letterSpacing": "0.01071em",
-            "lineHeight": "17px",
-          },
-          "body3": Object {
-            "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "10px",
-            "fontWeight": 400,
-            "letterSpacing": "0.01071em",
-            "lineHeight": "14px",
+            "lineHeight": "16px",
+            "mobile": Object {
+              "fontSize": "11px",
+              "lineHeight": "16px",
+            },
           },
           "button": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "14px",
+            "fontSize": "13px",
             "fontWeight": 500,
             "letterSpacing": "0.02857em",
-            "lineHeight": 1.75,
+            "lineHeight": "20px",
           },
           "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
           "fontWeight": Object {
@@ -177,13 +189,21 @@ exports[`<Button> renders correct snapshot 1`] = `
             "fontWeight": 500,
             "letterSpacing": "-0.01562em",
             "lineHeight": "56px",
+            "mobile": Object {
+              "fontSize": "30px",
+              "lineHeight": "44px",
+            },
           },
           "h2": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "30px",
             "fontWeight": 500,
             "letterSpacing": "-0.00833em",
-            "lineHeight": "42px",
+            "lineHeight": "44px",
+            "mobile": Object {
+              "fontSize": "22px",
+              "lineHeight": "32px",
+            },
           },
           "h3": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
@@ -191,20 +211,32 @@ exports[`<Button> renders correct snapshot 1`] = `
             "fontWeight": 500,
             "letterSpacing": "0em",
             "lineHeight": "32px",
+            "mobile": Object {
+              "fontSize": "18px",
+              "lineHeight": "28px",
+            },
           },
           "h4": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "20px",
             "fontWeight": 400,
             "letterSpacing": "-0.00735em",
-            "lineHeight": "30px",
+            "lineHeight": "28px",
+            "mobile": Object {
+              "fontSize": "16px",
+              "lineHeight": "24px",
+            },
           },
           "h5": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "16px",
             "fontWeight": 400,
             "letterSpacing": "0rem",
-            "lineHeight": "23px",
+            "lineHeight": "24px",
+            "mobile": Object {
+              "fontSize": "14px",
+              "lineHeight": "20px",
+            },
           },
         },
         "zIndex": Object {

--- a/packages/riipen-ui/src/components/__snapshots__/ButtonIcon.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/ButtonIcon.test.jsx.snap
@@ -133,31 +133,43 @@ exports[`<ButtonIcon> renders correct snapshot 1`] = `
         "typography": Object {
           "body1": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "14px",
+            "fontSize": "16px",
             "fontWeight": 400,
             "letterSpacing": "0.00938em",
-            "lineHeight": "20px",
+            "lineHeight": "24px",
+            "mobile": Object {
+              "fontSize": "14px",
+              "lineHeight": "20px",
+            },
           },
           "body2": Object {
+            "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
+            "fontSize": "14px",
+            "fontWeight": 400,
+            "letterSpacing": "0.01071em",
+            "lineHeight": "20px",
+            "mobile": Object {
+              "fontSize": "12px",
+              "lineHeight": "16px",
+            },
+          },
+          "body3": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "12px",
             "fontWeight": 400,
             "letterSpacing": "0.01071em",
-            "lineHeight": "17px",
-          },
-          "body3": Object {
-            "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "10px",
-            "fontWeight": 400,
-            "letterSpacing": "0.01071em",
-            "lineHeight": "14px",
+            "lineHeight": "16px",
+            "mobile": Object {
+              "fontSize": "11px",
+              "lineHeight": "16px",
+            },
           },
           "button": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "14px",
+            "fontSize": "13px",
             "fontWeight": 500,
             "letterSpacing": "0.02857em",
-            "lineHeight": 1.75,
+            "lineHeight": "20px",
           },
           "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
           "fontWeight": Object {
@@ -172,13 +184,21 @@ exports[`<ButtonIcon> renders correct snapshot 1`] = `
             "fontWeight": 500,
             "letterSpacing": "-0.01562em",
             "lineHeight": "56px",
+            "mobile": Object {
+              "fontSize": "30px",
+              "lineHeight": "44px",
+            },
           },
           "h2": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "30px",
             "fontWeight": 500,
             "letterSpacing": "-0.00833em",
-            "lineHeight": "42px",
+            "lineHeight": "44px",
+            "mobile": Object {
+              "fontSize": "22px",
+              "lineHeight": "32px",
+            },
           },
           "h3": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
@@ -186,20 +206,32 @@ exports[`<ButtonIcon> renders correct snapshot 1`] = `
             "fontWeight": 500,
             "letterSpacing": "0em",
             "lineHeight": "32px",
+            "mobile": Object {
+              "fontSize": "18px",
+              "lineHeight": "28px",
+            },
           },
           "h4": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "20px",
             "fontWeight": 400,
             "letterSpacing": "-0.00735em",
-            "lineHeight": "30px",
+            "lineHeight": "28px",
+            "mobile": Object {
+              "fontSize": "16px",
+              "lineHeight": "24px",
+            },
           },
           "h5": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "16px",
             "fontWeight": 400,
             "letterSpacing": "0rem",
-            "lineHeight": "23px",
+            "lineHeight": "24px",
+            "mobile": Object {
+              "fontSize": "14px",
+              "lineHeight": "20px",
+            },
           },
         },
         "zIndex": Object {
@@ -354,31 +386,43 @@ exports[`<ButtonIcon> renders correct snapshot 1`] = `
           "typography": Object {
             "body1": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-              "fontSize": "14px",
+              "fontSize": "16px",
               "fontWeight": 400,
               "letterSpacing": "0.00938em",
-              "lineHeight": "20px",
+              "lineHeight": "24px",
+              "mobile": Object {
+                "fontSize": "14px",
+                "lineHeight": "20px",
+              },
             },
             "body2": Object {
+              "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
+              "fontSize": "14px",
+              "fontWeight": 400,
+              "letterSpacing": "0.01071em",
+              "lineHeight": "20px",
+              "mobile": Object {
+                "fontSize": "12px",
+                "lineHeight": "16px",
+              },
+            },
+            "body3": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
               "fontSize": "12px",
               "fontWeight": 400,
               "letterSpacing": "0.01071em",
-              "lineHeight": "17px",
-            },
-            "body3": Object {
-              "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-              "fontSize": "10px",
-              "fontWeight": 400,
-              "letterSpacing": "0.01071em",
-              "lineHeight": "14px",
+              "lineHeight": "16px",
+              "mobile": Object {
+                "fontSize": "11px",
+                "lineHeight": "16px",
+              },
             },
             "button": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-              "fontSize": "14px",
+              "fontSize": "13px",
               "fontWeight": 500,
               "letterSpacing": "0.02857em",
-              "lineHeight": 1.75,
+              "lineHeight": "20px",
             },
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontWeight": Object {
@@ -393,13 +437,21 @@ exports[`<ButtonIcon> renders correct snapshot 1`] = `
               "fontWeight": 500,
               "letterSpacing": "-0.01562em",
               "lineHeight": "56px",
+              "mobile": Object {
+                "fontSize": "30px",
+                "lineHeight": "44px",
+              },
             },
             "h2": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
               "fontSize": "30px",
               "fontWeight": 500,
               "letterSpacing": "-0.00833em",
-              "lineHeight": "42px",
+              "lineHeight": "44px",
+              "mobile": Object {
+                "fontSize": "22px",
+                "lineHeight": "32px",
+              },
             },
             "h3": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
@@ -407,20 +459,32 @@ exports[`<ButtonIcon> renders correct snapshot 1`] = `
               "fontWeight": 500,
               "letterSpacing": "0em",
               "lineHeight": "32px",
+              "mobile": Object {
+                "fontSize": "18px",
+                "lineHeight": "28px",
+              },
             },
             "h4": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
               "fontSize": "20px",
               "fontWeight": 400,
               "letterSpacing": "-0.00735em",
-              "lineHeight": "30px",
+              "lineHeight": "28px",
+              "mobile": Object {
+                "fontSize": "16px",
+                "lineHeight": "24px",
+              },
             },
             "h5": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
               "fontSize": "16px",
               "fontWeight": 400,
               "letterSpacing": "0rem",
-              "lineHeight": "23px",
+              "lineHeight": "24px",
+              "mobile": Object {
+                "fontSize": "14px",
+                "lineHeight": "20px",
+              },
             },
           },
           "zIndex": Object {

--- a/packages/riipen-ui/src/components/__snapshots__/Checkbox.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Checkbox.test.jsx.snap
@@ -139,31 +139,43 @@ exports[`<Checkbox> renders correct snapshot 1`] = `
         "typography": Object {
           "body1": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "14px",
+            "fontSize": "16px",
             "fontWeight": 400,
             "letterSpacing": "0.00938em",
-            "lineHeight": "20px",
+            "lineHeight": "24px",
+            "mobile": Object {
+              "fontSize": "14px",
+              "lineHeight": "20px",
+            },
           },
           "body2": Object {
+            "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
+            "fontSize": "14px",
+            "fontWeight": 400,
+            "letterSpacing": "0.01071em",
+            "lineHeight": "20px",
+            "mobile": Object {
+              "fontSize": "12px",
+              "lineHeight": "16px",
+            },
+          },
+          "body3": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "12px",
             "fontWeight": 400,
             "letterSpacing": "0.01071em",
-            "lineHeight": "17px",
-          },
-          "body3": Object {
-            "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "10px",
-            "fontWeight": 400,
-            "letterSpacing": "0.01071em",
-            "lineHeight": "14px",
+            "lineHeight": "16px",
+            "mobile": Object {
+              "fontSize": "11px",
+              "lineHeight": "16px",
+            },
           },
           "button": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "14px",
+            "fontSize": "13px",
             "fontWeight": 500,
             "letterSpacing": "0.02857em",
-            "lineHeight": 1.75,
+            "lineHeight": "20px",
           },
           "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
           "fontWeight": Object {
@@ -178,13 +190,21 @@ exports[`<Checkbox> renders correct snapshot 1`] = `
             "fontWeight": 500,
             "letterSpacing": "-0.01562em",
             "lineHeight": "56px",
+            "mobile": Object {
+              "fontSize": "30px",
+              "lineHeight": "44px",
+            },
           },
           "h2": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "30px",
             "fontWeight": 500,
             "letterSpacing": "-0.00833em",
-            "lineHeight": "42px",
+            "lineHeight": "44px",
+            "mobile": Object {
+              "fontSize": "22px",
+              "lineHeight": "32px",
+            },
           },
           "h3": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
@@ -192,20 +212,32 @@ exports[`<Checkbox> renders correct snapshot 1`] = `
             "fontWeight": 500,
             "letterSpacing": "0em",
             "lineHeight": "32px",
+            "mobile": Object {
+              "fontSize": "18px",
+              "lineHeight": "28px",
+            },
           },
           "h4": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "20px",
             "fontWeight": 400,
             "letterSpacing": "-0.00735em",
-            "lineHeight": "30px",
+            "lineHeight": "28px",
+            "mobile": Object {
+              "fontSize": "16px",
+              "lineHeight": "24px",
+            },
           },
           "h5": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "16px",
             "fontWeight": 400,
             "letterSpacing": "0rem",
-            "lineHeight": "23px",
+            "lineHeight": "24px",
+            "mobile": Object {
+              "fontSize": "14px",
+              "lineHeight": "20px",
+            },
           },
         },
         "zIndex": Object {
@@ -237,12 +269,13 @@ exports[`<Checkbox> renders correct snapshot 1`] = `
             color="inherit"
             display="initial"
             gutter={false}
+            mobileBreakpoint="sm"
             textAlign="inherit"
             textTransform="inherit"
             variant="body1"
           >
             <p
-              className="jsx-1194261709 root color-inherit initial body1 align-inherit transform-inherit riipen riipen-typography"
+              className="jsx-2087479458 root color-inherit initial mobile body1 align-inherit transform-inherit riipen riipen-typography"
             />
             <JSXStyle
               dynamic={
@@ -250,20 +283,20 @@ exports[`<Checkbox> renders correct snapshot 1`] = `
                   "#424242",
                   "Roboto, Helvetica, Arial, sans-serif",
                   400,
-                  "14px",
-                  "20px",
+                  "16px",
+                  "24px",
                   "0.00938em",
                   "#424242",
                   "Roboto, Helvetica, Arial, sans-serif",
                   400,
-                  "12px",
-                  "17px",
+                  "14px",
+                  "20px",
                   "0.01071em",
                   "#424242",
                   "Roboto, Helvetica, Arial, sans-serif",
                   400,
-                  "10px",
-                  "14px",
+                  "12px",
+                  "16px",
                   "0.01071em",
                   "#373737",
                   "Roboto, Helvetica, Arial, sans-serif",
@@ -275,7 +308,7 @@ exports[`<Checkbox> renders correct snapshot 1`] = `
                   "Roboto, Helvetica, Arial, sans-serif",
                   500,
                   "30px",
-                  "42px",
+                  "44px",
                   "-0.00833em",
                   "#373737",
                   "Roboto, Helvetica, Arial, sans-serif",
@@ -287,13 +320,13 @@ exports[`<Checkbox> renders correct snapshot 1`] = `
                   "Roboto, Helvetica, Arial, sans-serif",
                   400,
                   "20px",
-                  "30px",
+                  "28px",
                   "-0.00735em",
                   "#373737",
                   "Roboto, Helvetica, Arial, sans-serif",
                   400,
                   "16px",
-                  "23px",
+                  "24px",
                   "0rem",
                   "#000",
                   "#cccbcb",
@@ -312,9 +345,26 @@ exports[`<Checkbox> renders correct snapshot 1`] = `
                   300,
                   500,
                   400,
+                  600,
+                  "14px",
+                  "20px",
+                  "12px",
+                  "16px",
+                  "11px",
+                  "16px",
+                  "30px",
+                  "44px",
+                  "22px",
+                  "32px",
+                  "18px",
+                  "28px",
+                  "16px",
+                  "24px",
+                  "14px",
+                  "20px",
                 ]
               }
-              id="3194901921"
+              id="585098619"
             />
           </Typography>
         </withClasses(Typography)>

--- a/packages/riipen-ui/src/components/__snapshots__/Chip.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Chip.test.jsx.snap
@@ -133,31 +133,43 @@ exports[`<Chip> renders correct snapshot 1`] = `
         "typography": Object {
           "body1": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "14px",
+            "fontSize": "16px",
             "fontWeight": 400,
             "letterSpacing": "0.00938em",
-            "lineHeight": "20px",
+            "lineHeight": "24px",
+            "mobile": Object {
+              "fontSize": "14px",
+              "lineHeight": "20px",
+            },
           },
           "body2": Object {
+            "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
+            "fontSize": "14px",
+            "fontWeight": 400,
+            "letterSpacing": "0.01071em",
+            "lineHeight": "20px",
+            "mobile": Object {
+              "fontSize": "12px",
+              "lineHeight": "16px",
+            },
+          },
+          "body3": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "12px",
             "fontWeight": 400,
             "letterSpacing": "0.01071em",
-            "lineHeight": "17px",
-          },
-          "body3": Object {
-            "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "10px",
-            "fontWeight": 400,
-            "letterSpacing": "0.01071em",
-            "lineHeight": "14px",
+            "lineHeight": "16px",
+            "mobile": Object {
+              "fontSize": "11px",
+              "lineHeight": "16px",
+            },
           },
           "button": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "14px",
+            "fontSize": "13px",
             "fontWeight": 500,
             "letterSpacing": "0.02857em",
-            "lineHeight": 1.75,
+            "lineHeight": "20px",
           },
           "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
           "fontWeight": Object {
@@ -172,13 +184,21 @@ exports[`<Chip> renders correct snapshot 1`] = `
             "fontWeight": 500,
             "letterSpacing": "-0.01562em",
             "lineHeight": "56px",
+            "mobile": Object {
+              "fontSize": "30px",
+              "lineHeight": "44px",
+            },
           },
           "h2": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "30px",
             "fontWeight": 500,
             "letterSpacing": "-0.00833em",
-            "lineHeight": "42px",
+            "lineHeight": "44px",
+            "mobile": Object {
+              "fontSize": "22px",
+              "lineHeight": "32px",
+            },
           },
           "h3": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
@@ -186,20 +206,32 @@ exports[`<Chip> renders correct snapshot 1`] = `
             "fontWeight": 500,
             "letterSpacing": "0em",
             "lineHeight": "32px",
+            "mobile": Object {
+              "fontSize": "18px",
+              "lineHeight": "28px",
+            },
           },
           "h4": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "20px",
             "fontWeight": 400,
             "letterSpacing": "-0.00735em",
-            "lineHeight": "30px",
+            "lineHeight": "28px",
+            "mobile": Object {
+              "fontSize": "16px",
+              "lineHeight": "24px",
+            },
           },
           "h5": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "16px",
             "fontWeight": 400,
             "letterSpacing": "0rem",
-            "lineHeight": "23px",
+            "lineHeight": "24px",
+            "mobile": Object {
+              "fontSize": "14px",
+              "lineHeight": "20px",
+            },
           },
         },
         "zIndex": Object {
@@ -356,31 +388,43 @@ exports[`<Chip> renders correct snapshot 1`] = `
           "typography": Object {
             "body1": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-              "fontSize": "14px",
+              "fontSize": "16px",
               "fontWeight": 400,
               "letterSpacing": "0.00938em",
-              "lineHeight": "20px",
+              "lineHeight": "24px",
+              "mobile": Object {
+                "fontSize": "14px",
+                "lineHeight": "20px",
+              },
             },
             "body2": Object {
+              "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
+              "fontSize": "14px",
+              "fontWeight": 400,
+              "letterSpacing": "0.01071em",
+              "lineHeight": "20px",
+              "mobile": Object {
+                "fontSize": "12px",
+                "lineHeight": "16px",
+              },
+            },
+            "body3": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
               "fontSize": "12px",
               "fontWeight": 400,
               "letterSpacing": "0.01071em",
-              "lineHeight": "17px",
-            },
-            "body3": Object {
-              "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-              "fontSize": "10px",
-              "fontWeight": 400,
-              "letterSpacing": "0.01071em",
-              "lineHeight": "14px",
+              "lineHeight": "16px",
+              "mobile": Object {
+                "fontSize": "11px",
+                "lineHeight": "16px",
+              },
             },
             "button": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-              "fontSize": "14px",
+              "fontSize": "13px",
               "fontWeight": 500,
               "letterSpacing": "0.02857em",
-              "lineHeight": 1.75,
+              "lineHeight": "20px",
             },
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontWeight": Object {
@@ -395,13 +439,21 @@ exports[`<Chip> renders correct snapshot 1`] = `
               "fontWeight": 500,
               "letterSpacing": "-0.01562em",
               "lineHeight": "56px",
+              "mobile": Object {
+                "fontSize": "30px",
+                "lineHeight": "44px",
+              },
             },
             "h2": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
               "fontSize": "30px",
               "fontWeight": 500,
               "letterSpacing": "-0.00833em",
-              "lineHeight": "42px",
+              "lineHeight": "44px",
+              "mobile": Object {
+                "fontSize": "22px",
+                "lineHeight": "32px",
+              },
             },
             "h3": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
@@ -409,20 +461,32 @@ exports[`<Chip> renders correct snapshot 1`] = `
               "fontWeight": 500,
               "letterSpacing": "0em",
               "lineHeight": "32px",
+              "mobile": Object {
+                "fontSize": "18px",
+                "lineHeight": "28px",
+              },
             },
             "h4": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
               "fontSize": "20px",
               "fontWeight": 400,
               "letterSpacing": "-0.00735em",
-              "lineHeight": "30px",
+              "lineHeight": "28px",
+              "mobile": Object {
+                "fontSize": "16px",
+                "lineHeight": "24px",
+              },
             },
             "h5": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
               "fontSize": "16px",
               "fontWeight": 400,
               "letterSpacing": "0rem",
-              "lineHeight": "23px",
+              "lineHeight": "24px",
+              "mobile": Object {
+                "fontSize": "14px",
+                "lineHeight": "20px",
+              },
             },
           },
           "zIndex": Object {
@@ -439,12 +503,12 @@ exports[`<Chip> renders correct snapshot 1`] = `
       variant="default"
     >
       <div
-        className="jsx-1000837380 root default medium default riipen riipen-chip"
+        className="jsx-3490229190 root default medium default riipen riipen-chip"
         onBlur={[Function]}
         onFocus={[Function]}
       >
         <span
-          className="jsx-1000837380 label"
+          className="jsx-3490229190 label"
         />
       </div>
       <JSXStyle
@@ -453,7 +517,7 @@ exports[`<Chip> renders correct snapshot 1`] = `
             "#dddddd",
             "#747474",
             "Roboto, Helvetica, Arial, sans-serif",
-            "14px",
+            "16px",
             5,
             5,
             10,

--- a/packages/riipen-ui/src/components/__snapshots__/Input.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Input.test.jsx.snap
@@ -136,31 +136,43 @@ exports[`<Input> renders correct snapshot 1`] = `
         "typography": Object {
           "body1": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "14px",
+            "fontSize": "16px",
             "fontWeight": 400,
             "letterSpacing": "0.00938em",
-            "lineHeight": "20px",
+            "lineHeight": "24px",
+            "mobile": Object {
+              "fontSize": "14px",
+              "lineHeight": "20px",
+            },
           },
           "body2": Object {
+            "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
+            "fontSize": "14px",
+            "fontWeight": 400,
+            "letterSpacing": "0.01071em",
+            "lineHeight": "20px",
+            "mobile": Object {
+              "fontSize": "12px",
+              "lineHeight": "16px",
+            },
+          },
+          "body3": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "12px",
             "fontWeight": 400,
             "letterSpacing": "0.01071em",
-            "lineHeight": "17px",
-          },
-          "body3": Object {
-            "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "10px",
-            "fontWeight": 400,
-            "letterSpacing": "0.01071em",
-            "lineHeight": "14px",
+            "lineHeight": "16px",
+            "mobile": Object {
+              "fontSize": "11px",
+              "lineHeight": "16px",
+            },
           },
           "button": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "14px",
+            "fontSize": "13px",
             "fontWeight": 500,
             "letterSpacing": "0.02857em",
-            "lineHeight": 1.75,
+            "lineHeight": "20px",
           },
           "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
           "fontWeight": Object {
@@ -175,13 +187,21 @@ exports[`<Input> renders correct snapshot 1`] = `
             "fontWeight": 500,
             "letterSpacing": "-0.01562em",
             "lineHeight": "56px",
+            "mobile": Object {
+              "fontSize": "30px",
+              "lineHeight": "44px",
+            },
           },
           "h2": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "30px",
             "fontWeight": 500,
             "letterSpacing": "-0.00833em",
-            "lineHeight": "42px",
+            "lineHeight": "44px",
+            "mobile": Object {
+              "fontSize": "22px",
+              "lineHeight": "32px",
+            },
           },
           "h3": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
@@ -189,20 +209,32 @@ exports[`<Input> renders correct snapshot 1`] = `
             "fontWeight": 500,
             "letterSpacing": "0em",
             "lineHeight": "32px",
+            "mobile": Object {
+              "fontSize": "18px",
+              "lineHeight": "28px",
+            },
           },
           "h4": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "20px",
             "fontWeight": 400,
             "letterSpacing": "-0.00735em",
-            "lineHeight": "30px",
+            "lineHeight": "28px",
+            "mobile": Object {
+              "fontSize": "16px",
+              "lineHeight": "24px",
+            },
           },
           "h5": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "16px",
             "fontWeight": 400,
             "letterSpacing": "0rem",
-            "lineHeight": "23px",
+            "lineHeight": "24px",
+            "mobile": Object {
+              "fontSize": "14px",
+              "lineHeight": "20px",
+            },
           },
         },
         "zIndex": Object {
@@ -219,11 +251,11 @@ exports[`<Input> renders correct snapshot 1`] = `
     variant="default"
   >
     <div
-      className="jsx-1488736700 wrapper"
+      className="jsx-2125438072 wrapper"
     >
       <input
         aria-disabled={false}
-        className="jsx-1488736700 default medium"
+        className="jsx-2125438072 default medium"
         disabled={false}
         onBlur={[Function]}
         onFocus={[Function]}
@@ -233,7 +265,7 @@ exports[`<Input> renders correct snapshot 1`] = `
           Array [
             "20px",
             "16px",
-            "12px",
+            "14px",
             "#fff",
             "4px",
             "30px",
@@ -243,7 +275,7 @@ exports[`<Input> renders correct snapshot 1`] = `
             "#e95353",
             "#373737",
             "Roboto, Helvetica, Arial, sans-serif",
-            "14px",
+            "16px",
             10,
             300,
             "#3caabb",

--- a/packages/riipen-ui/src/components/__snapshots__/InputHint.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/InputHint.test.jsx.snap
@@ -133,31 +133,43 @@ exports[`<InputHint> renders correct snapshot 1`] = `
         "typography": Object {
           "body1": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "14px",
+            "fontSize": "16px",
             "fontWeight": 400,
             "letterSpacing": "0.00938em",
-            "lineHeight": "20px",
+            "lineHeight": "24px",
+            "mobile": Object {
+              "fontSize": "14px",
+              "lineHeight": "20px",
+            },
           },
           "body2": Object {
+            "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
+            "fontSize": "14px",
+            "fontWeight": 400,
+            "letterSpacing": "0.01071em",
+            "lineHeight": "20px",
+            "mobile": Object {
+              "fontSize": "12px",
+              "lineHeight": "16px",
+            },
+          },
+          "body3": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "12px",
             "fontWeight": 400,
             "letterSpacing": "0.01071em",
-            "lineHeight": "17px",
-          },
-          "body3": Object {
-            "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "10px",
-            "fontWeight": 400,
-            "letterSpacing": "0.01071em",
-            "lineHeight": "14px",
+            "lineHeight": "16px",
+            "mobile": Object {
+              "fontSize": "11px",
+              "lineHeight": "16px",
+            },
           },
           "button": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "14px",
+            "fontSize": "13px",
             "fontWeight": 500,
             "letterSpacing": "0.02857em",
-            "lineHeight": 1.75,
+            "lineHeight": "20px",
           },
           "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
           "fontWeight": Object {
@@ -172,13 +184,21 @@ exports[`<InputHint> renders correct snapshot 1`] = `
             "fontWeight": 500,
             "letterSpacing": "-0.01562em",
             "lineHeight": "56px",
+            "mobile": Object {
+              "fontSize": "30px",
+              "lineHeight": "44px",
+            },
           },
           "h2": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "30px",
             "fontWeight": 500,
             "letterSpacing": "-0.00833em",
-            "lineHeight": "42px",
+            "lineHeight": "44px",
+            "mobile": Object {
+              "fontSize": "22px",
+              "lineHeight": "32px",
+            },
           },
           "h3": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
@@ -186,20 +206,32 @@ exports[`<InputHint> renders correct snapshot 1`] = `
             "fontWeight": 500,
             "letterSpacing": "0em",
             "lineHeight": "32px",
+            "mobile": Object {
+              "fontSize": "18px",
+              "lineHeight": "28px",
+            },
           },
           "h4": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "20px",
             "fontWeight": 400,
             "letterSpacing": "-0.00735em",
-            "lineHeight": "30px",
+            "lineHeight": "28px",
+            "mobile": Object {
+              "fontSize": "16px",
+              "lineHeight": "24px",
+            },
           },
           "h5": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "16px",
             "fontWeight": 400,
             "letterSpacing": "0rem",
-            "lineHeight": "23px",
+            "lineHeight": "24px",
+            "mobile": Object {
+              "fontSize": "14px",
+              "lineHeight": "20px",
+            },
           },
         },
         "zIndex": Object {
@@ -352,31 +384,43 @@ exports[`<InputHint> renders correct snapshot 1`] = `
           "typography": Object {
             "body1": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-              "fontSize": "14px",
+              "fontSize": "16px",
               "fontWeight": 400,
               "letterSpacing": "0.00938em",
-              "lineHeight": "20px",
+              "lineHeight": "24px",
+              "mobile": Object {
+                "fontSize": "14px",
+                "lineHeight": "20px",
+              },
             },
             "body2": Object {
+              "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
+              "fontSize": "14px",
+              "fontWeight": 400,
+              "letterSpacing": "0.01071em",
+              "lineHeight": "20px",
+              "mobile": Object {
+                "fontSize": "12px",
+                "lineHeight": "16px",
+              },
+            },
+            "body3": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
               "fontSize": "12px",
               "fontWeight": 400,
               "letterSpacing": "0.01071em",
-              "lineHeight": "17px",
-            },
-            "body3": Object {
-              "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-              "fontSize": "10px",
-              "fontWeight": 400,
-              "letterSpacing": "0.01071em",
-              "lineHeight": "14px",
+              "lineHeight": "16px",
+              "mobile": Object {
+                "fontSize": "11px",
+                "lineHeight": "16px",
+              },
             },
             "button": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-              "fontSize": "14px",
+              "fontSize": "13px",
               "fontWeight": 500,
               "letterSpacing": "0.02857em",
-              "lineHeight": 1.75,
+              "lineHeight": "20px",
             },
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontWeight": Object {
@@ -391,13 +435,21 @@ exports[`<InputHint> renders correct snapshot 1`] = `
               "fontWeight": 500,
               "letterSpacing": "-0.01562em",
               "lineHeight": "56px",
+              "mobile": Object {
+                "fontSize": "30px",
+                "lineHeight": "44px",
+              },
             },
             "h2": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
               "fontSize": "30px",
               "fontWeight": 500,
               "letterSpacing": "-0.00833em",
-              "lineHeight": "42px",
+              "lineHeight": "44px",
+              "mobile": Object {
+                "fontSize": "22px",
+                "lineHeight": "32px",
+              },
             },
             "h3": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
@@ -405,20 +457,32 @@ exports[`<InputHint> renders correct snapshot 1`] = `
               "fontWeight": 500,
               "letterSpacing": "0em",
               "lineHeight": "32px",
+              "mobile": Object {
+                "fontSize": "18px",
+                "lineHeight": "28px",
+              },
             },
             "h4": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
               "fontSize": "20px",
               "fontWeight": 400,
               "letterSpacing": "-0.00735em",
-              "lineHeight": "30px",
+              "lineHeight": "28px",
+              "mobile": Object {
+                "fontSize": "16px",
+                "lineHeight": "24px",
+              },
             },
             "h5": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
               "fontSize": "16px",
               "fontWeight": 400,
               "letterSpacing": "0rem",
-              "lineHeight": "23px",
+              "lineHeight": "24px",
+              "mobile": Object {
+                "fontSize": "14px",
+                "lineHeight": "20px",
+              },
             },
           },
           "zIndex": Object {
@@ -450,12 +514,13 @@ exports[`<InputHint> renders correct snapshot 1`] = `
             color="inherit"
             display="initial"
             gutter={false}
+            mobileBreakpoint="sm"
             textAlign="inherit"
             textTransform="inherit"
             variant="body2"
           >
             <p
-              className="jsx-1194261709 root color-inherit initial body2 align-inherit transform-inherit riipen riipen-typography"
+              className="jsx-2087479458 root color-inherit initial mobile body2 align-inherit transform-inherit riipen riipen-typography"
             />
             <JSXStyle
               dynamic={
@@ -463,20 +528,20 @@ exports[`<InputHint> renders correct snapshot 1`] = `
                   "#424242",
                   "Roboto, Helvetica, Arial, sans-serif",
                   400,
-                  "14px",
-                  "20px",
+                  "16px",
+                  "24px",
                   "0.00938em",
                   "#424242",
                   "Roboto, Helvetica, Arial, sans-serif",
                   400,
-                  "12px",
-                  "17px",
+                  "14px",
+                  "20px",
                   "0.01071em",
                   "#424242",
                   "Roboto, Helvetica, Arial, sans-serif",
                   400,
-                  "10px",
-                  "14px",
+                  "12px",
+                  "16px",
                   "0.01071em",
                   "#373737",
                   "Roboto, Helvetica, Arial, sans-serif",
@@ -488,7 +553,7 @@ exports[`<InputHint> renders correct snapshot 1`] = `
                   "Roboto, Helvetica, Arial, sans-serif",
                   500,
                   "30px",
-                  "42px",
+                  "44px",
                   "-0.00833em",
                   "#373737",
                   "Roboto, Helvetica, Arial, sans-serif",
@@ -500,13 +565,13 @@ exports[`<InputHint> renders correct snapshot 1`] = `
                   "Roboto, Helvetica, Arial, sans-serif",
                   400,
                   "20px",
-                  "30px",
+                  "28px",
                   "-0.00735em",
                   "#373737",
                   "Roboto, Helvetica, Arial, sans-serif",
                   400,
                   "16px",
-                  "23px",
+                  "24px",
                   "0rem",
                   "#000",
                   "#cccbcb",
@@ -525,9 +590,26 @@ exports[`<InputHint> renders correct snapshot 1`] = `
                   300,
                   500,
                   400,
+                  600,
+                  "14px",
+                  "20px",
+                  "12px",
+                  "16px",
+                  "11px",
+                  "16px",
+                  "30px",
+                  "44px",
+                  "22px",
+                  "32px",
+                  "18px",
+                  "28px",
+                  "16px",
+                  "24px",
+                  "14px",
+                  "20px",
                 ]
               }
-              id="3194901921"
+              id="585098619"
             />
           </Typography>
         </withClasses(Typography)>

--- a/packages/riipen-ui/src/components/__snapshots__/InputLabel.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/InputLabel.test.jsx.snap
@@ -133,31 +133,43 @@ exports[`<InputLabel> renders correct snapshot 1`] = `
         "typography": Object {
           "body1": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "14px",
+            "fontSize": "16px",
             "fontWeight": 400,
             "letterSpacing": "0.00938em",
-            "lineHeight": "20px",
+            "lineHeight": "24px",
+            "mobile": Object {
+              "fontSize": "14px",
+              "lineHeight": "20px",
+            },
           },
           "body2": Object {
+            "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
+            "fontSize": "14px",
+            "fontWeight": 400,
+            "letterSpacing": "0.01071em",
+            "lineHeight": "20px",
+            "mobile": Object {
+              "fontSize": "12px",
+              "lineHeight": "16px",
+            },
+          },
+          "body3": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "12px",
             "fontWeight": 400,
             "letterSpacing": "0.01071em",
-            "lineHeight": "17px",
-          },
-          "body3": Object {
-            "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "10px",
-            "fontWeight": 400,
-            "letterSpacing": "0.01071em",
-            "lineHeight": "14px",
+            "lineHeight": "16px",
+            "mobile": Object {
+              "fontSize": "11px",
+              "lineHeight": "16px",
+            },
           },
           "button": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "14px",
+            "fontSize": "13px",
             "fontWeight": 500,
             "letterSpacing": "0.02857em",
-            "lineHeight": 1.75,
+            "lineHeight": "20px",
           },
           "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
           "fontWeight": Object {
@@ -172,13 +184,21 @@ exports[`<InputLabel> renders correct snapshot 1`] = `
             "fontWeight": 500,
             "letterSpacing": "-0.01562em",
             "lineHeight": "56px",
+            "mobile": Object {
+              "fontSize": "30px",
+              "lineHeight": "44px",
+            },
           },
           "h2": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "30px",
             "fontWeight": 500,
             "letterSpacing": "-0.00833em",
-            "lineHeight": "42px",
+            "lineHeight": "44px",
+            "mobile": Object {
+              "fontSize": "22px",
+              "lineHeight": "32px",
+            },
           },
           "h3": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
@@ -186,20 +206,32 @@ exports[`<InputLabel> renders correct snapshot 1`] = `
             "fontWeight": 500,
             "letterSpacing": "0em",
             "lineHeight": "32px",
+            "mobile": Object {
+              "fontSize": "18px",
+              "lineHeight": "28px",
+            },
           },
           "h4": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "20px",
             "fontWeight": 400,
             "letterSpacing": "-0.00735em",
-            "lineHeight": "30px",
+            "lineHeight": "28px",
+            "mobile": Object {
+              "fontSize": "16px",
+              "lineHeight": "24px",
+            },
           },
           "h5": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "16px",
             "fontWeight": 400,
             "letterSpacing": "0rem",
-            "lineHeight": "23px",
+            "lineHeight": "24px",
+            "mobile": Object {
+              "fontSize": "14px",
+              "lineHeight": "20px",
+            },
           },
         },
         "zIndex": Object {
@@ -354,31 +386,43 @@ exports[`<InputLabel> renders correct snapshot 1`] = `
           "typography": Object {
             "body1": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-              "fontSize": "14px",
+              "fontSize": "16px",
               "fontWeight": 400,
               "letterSpacing": "0.00938em",
-              "lineHeight": "20px",
+              "lineHeight": "24px",
+              "mobile": Object {
+                "fontSize": "14px",
+                "lineHeight": "20px",
+              },
             },
             "body2": Object {
+              "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
+              "fontSize": "14px",
+              "fontWeight": 400,
+              "letterSpacing": "0.01071em",
+              "lineHeight": "20px",
+              "mobile": Object {
+                "fontSize": "12px",
+                "lineHeight": "16px",
+              },
+            },
+            "body3": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
               "fontSize": "12px",
               "fontWeight": 400,
               "letterSpacing": "0.01071em",
-              "lineHeight": "17px",
-            },
-            "body3": Object {
-              "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-              "fontSize": "10px",
-              "fontWeight": 400,
-              "letterSpacing": "0.01071em",
-              "lineHeight": "14px",
+              "lineHeight": "16px",
+              "mobile": Object {
+                "fontSize": "11px",
+                "lineHeight": "16px",
+              },
             },
             "button": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-              "fontSize": "14px",
+              "fontSize": "13px",
               "fontWeight": 500,
               "letterSpacing": "0.02857em",
-              "lineHeight": 1.75,
+              "lineHeight": "20px",
             },
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontWeight": Object {
@@ -393,13 +437,21 @@ exports[`<InputLabel> renders correct snapshot 1`] = `
               "fontWeight": 500,
               "letterSpacing": "-0.01562em",
               "lineHeight": "56px",
+              "mobile": Object {
+                "fontSize": "30px",
+                "lineHeight": "44px",
+              },
             },
             "h2": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
               "fontSize": "30px",
               "fontWeight": 500,
               "letterSpacing": "-0.00833em",
-              "lineHeight": "42px",
+              "lineHeight": "44px",
+              "mobile": Object {
+                "fontSize": "22px",
+                "lineHeight": "32px",
+              },
             },
             "h3": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
@@ -407,20 +459,32 @@ exports[`<InputLabel> renders correct snapshot 1`] = `
               "fontWeight": 500,
               "letterSpacing": "0em",
               "lineHeight": "32px",
+              "mobile": Object {
+                "fontSize": "18px",
+                "lineHeight": "28px",
+              },
             },
             "h4": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
               "fontSize": "20px",
               "fontWeight": 400,
               "letterSpacing": "-0.00735em",
-              "lineHeight": "30px",
+              "lineHeight": "28px",
+              "mobile": Object {
+                "fontSize": "16px",
+                "lineHeight": "24px",
+              },
             },
             "h5": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
               "fontSize": "16px",
               "fontWeight": 400,
               "letterSpacing": "0rem",
-              "lineHeight": "23px",
+              "lineHeight": "24px",
+              "mobile": Object {
+                "fontSize": "14px",
+                "lineHeight": "20px",
+              },
             },
           },
           "zIndex": Object {

--- a/packages/riipen-ui/src/components/__snapshots__/Link.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Link.test.jsx.snap
@@ -139,31 +139,43 @@ exports[`<Link> renders correct snapshot 1`] = `
         "typography": Object {
           "body1": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "14px",
+            "fontSize": "16px",
             "fontWeight": 400,
             "letterSpacing": "0.00938em",
-            "lineHeight": "20px",
+            "lineHeight": "24px",
+            "mobile": Object {
+              "fontSize": "14px",
+              "lineHeight": "20px",
+            },
           },
           "body2": Object {
+            "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
+            "fontSize": "14px",
+            "fontWeight": 400,
+            "letterSpacing": "0.01071em",
+            "lineHeight": "20px",
+            "mobile": Object {
+              "fontSize": "12px",
+              "lineHeight": "16px",
+            },
+          },
+          "body3": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "12px",
             "fontWeight": 400,
             "letterSpacing": "0.01071em",
-            "lineHeight": "17px",
-          },
-          "body3": Object {
-            "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "10px",
-            "fontWeight": 400,
-            "letterSpacing": "0.01071em",
-            "lineHeight": "14px",
+            "lineHeight": "16px",
+            "mobile": Object {
+              "fontSize": "11px",
+              "lineHeight": "16px",
+            },
           },
           "button": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "14px",
+            "fontSize": "13px",
             "fontWeight": 500,
             "letterSpacing": "0.02857em",
-            "lineHeight": 1.75,
+            "lineHeight": "20px",
           },
           "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
           "fontWeight": Object {
@@ -178,13 +190,21 @@ exports[`<Link> renders correct snapshot 1`] = `
             "fontWeight": 500,
             "letterSpacing": "-0.01562em",
             "lineHeight": "56px",
+            "mobile": Object {
+              "fontSize": "30px",
+              "lineHeight": "44px",
+            },
           },
           "h2": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "30px",
             "fontWeight": 500,
             "letterSpacing": "-0.00833em",
-            "lineHeight": "42px",
+            "lineHeight": "44px",
+            "mobile": Object {
+              "fontSize": "22px",
+              "lineHeight": "32px",
+            },
           },
           "h3": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
@@ -192,20 +212,32 @@ exports[`<Link> renders correct snapshot 1`] = `
             "fontWeight": 500,
             "letterSpacing": "0em",
             "lineHeight": "32px",
+            "mobile": Object {
+              "fontSize": "18px",
+              "lineHeight": "28px",
+            },
           },
           "h4": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "20px",
             "fontWeight": 400,
             "letterSpacing": "-0.00735em",
-            "lineHeight": "30px",
+            "lineHeight": "28px",
+            "mobile": Object {
+              "fontSize": "16px",
+              "lineHeight": "24px",
+            },
           },
           "h5": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "16px",
             "fontWeight": 400,
             "letterSpacing": "0rem",
-            "lineHeight": "23px",
+            "lineHeight": "24px",
+            "mobile": Object {
+              "fontSize": "14px",
+              "lineHeight": "20px",
+            },
           },
         },
         "zIndex": Object {

--- a/packages/riipen-ui/src/components/__snapshots__/ListItem.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/ListItem.test.jsx.snap
@@ -133,31 +133,43 @@ exports[`<ListItem> renders correct snapshot 1`] = `
         "typography": Object {
           "body1": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "14px",
+            "fontSize": "16px",
             "fontWeight": 400,
             "letterSpacing": "0.00938em",
-            "lineHeight": "20px",
+            "lineHeight": "24px",
+            "mobile": Object {
+              "fontSize": "14px",
+              "lineHeight": "20px",
+            },
           },
           "body2": Object {
+            "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
+            "fontSize": "14px",
+            "fontWeight": 400,
+            "letterSpacing": "0.01071em",
+            "lineHeight": "20px",
+            "mobile": Object {
+              "fontSize": "12px",
+              "lineHeight": "16px",
+            },
+          },
+          "body3": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "12px",
             "fontWeight": 400,
             "letterSpacing": "0.01071em",
-            "lineHeight": "17px",
-          },
-          "body3": Object {
-            "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "10px",
-            "fontWeight": 400,
-            "letterSpacing": "0.01071em",
-            "lineHeight": "14px",
+            "lineHeight": "16px",
+            "mobile": Object {
+              "fontSize": "11px",
+              "lineHeight": "16px",
+            },
           },
           "button": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "14px",
+            "fontSize": "13px",
             "fontWeight": 500,
             "letterSpacing": "0.02857em",
-            "lineHeight": 1.75,
+            "lineHeight": "20px",
           },
           "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
           "fontWeight": Object {
@@ -172,13 +184,21 @@ exports[`<ListItem> renders correct snapshot 1`] = `
             "fontWeight": 500,
             "letterSpacing": "-0.01562em",
             "lineHeight": "56px",
+            "mobile": Object {
+              "fontSize": "30px",
+              "lineHeight": "44px",
+            },
           },
           "h2": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "30px",
             "fontWeight": 500,
             "letterSpacing": "-0.00833em",
-            "lineHeight": "42px",
+            "lineHeight": "44px",
+            "mobile": Object {
+              "fontSize": "22px",
+              "lineHeight": "32px",
+            },
           },
           "h3": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
@@ -186,20 +206,32 @@ exports[`<ListItem> renders correct snapshot 1`] = `
             "fontWeight": 500,
             "letterSpacing": "0em",
             "lineHeight": "32px",
+            "mobile": Object {
+              "fontSize": "18px",
+              "lineHeight": "28px",
+            },
           },
           "h4": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "20px",
             "fontWeight": 400,
             "letterSpacing": "-0.00735em",
-            "lineHeight": "30px",
+            "lineHeight": "28px",
+            "mobile": Object {
+              "fontSize": "16px",
+              "lineHeight": "24px",
+            },
           },
           "h5": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "16px",
             "fontWeight": 400,
             "letterSpacing": "0rem",
-            "lineHeight": "23px",
+            "lineHeight": "24px",
+            "mobile": Object {
+              "fontSize": "14px",
+              "lineHeight": "20px",
+            },
           },
         },
         "zIndex": Object {
@@ -352,31 +384,43 @@ exports[`<ListItem> renders correct snapshot 1`] = `
           "typography": Object {
             "body1": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-              "fontSize": "14px",
+              "fontSize": "16px",
               "fontWeight": 400,
               "letterSpacing": "0.00938em",
-              "lineHeight": "20px",
+              "lineHeight": "24px",
+              "mobile": Object {
+                "fontSize": "14px",
+                "lineHeight": "20px",
+              },
             },
             "body2": Object {
+              "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
+              "fontSize": "14px",
+              "fontWeight": 400,
+              "letterSpacing": "0.01071em",
+              "lineHeight": "20px",
+              "mobile": Object {
+                "fontSize": "12px",
+                "lineHeight": "16px",
+              },
+            },
+            "body3": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
               "fontSize": "12px",
               "fontWeight": 400,
               "letterSpacing": "0.01071em",
-              "lineHeight": "17px",
-            },
-            "body3": Object {
-              "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-              "fontSize": "10px",
-              "fontWeight": 400,
-              "letterSpacing": "0.01071em",
-              "lineHeight": "14px",
+              "lineHeight": "16px",
+              "mobile": Object {
+                "fontSize": "11px",
+                "lineHeight": "16px",
+              },
             },
             "button": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-              "fontSize": "14px",
+              "fontSize": "13px",
               "fontWeight": 500,
               "letterSpacing": "0.02857em",
-              "lineHeight": 1.75,
+              "lineHeight": "20px",
             },
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontWeight": Object {
@@ -391,13 +435,21 @@ exports[`<ListItem> renders correct snapshot 1`] = `
               "fontWeight": 500,
               "letterSpacing": "-0.01562em",
               "lineHeight": "56px",
+              "mobile": Object {
+                "fontSize": "30px",
+                "lineHeight": "44px",
+              },
             },
             "h2": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
               "fontSize": "30px",
               "fontWeight": 500,
               "letterSpacing": "-0.00833em",
-              "lineHeight": "42px",
+              "lineHeight": "44px",
+              "mobile": Object {
+                "fontSize": "22px",
+                "lineHeight": "32px",
+              },
             },
             "h3": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
@@ -405,20 +457,32 @@ exports[`<ListItem> renders correct snapshot 1`] = `
               "fontWeight": 500,
               "letterSpacing": "0em",
               "lineHeight": "32px",
+              "mobile": Object {
+                "fontSize": "18px",
+                "lineHeight": "28px",
+              },
             },
             "h4": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
               "fontSize": "20px",
               "fontWeight": 400,
               "letterSpacing": "-0.00735em",
-              "lineHeight": "30px",
+              "lineHeight": "28px",
+              "mobile": Object {
+                "fontSize": "16px",
+                "lineHeight": "24px",
+              },
             },
             "h5": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
               "fontSize": "16px",
               "fontWeight": 400,
               "letterSpacing": "0rem",
-              "lineHeight": "23px",
+              "lineHeight": "24px",
+              "mobile": Object {
+                "fontSize": "14px",
+                "lineHeight": "20px",
+              },
             },
           },
           "zIndex": Object {

--- a/packages/riipen-ui/src/components/__snapshots__/MenuItem.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/MenuItem.test.jsx.snap
@@ -11,7 +11,7 @@ exports[`<MenuItem> renders correct snapshot 1`] = `
     }
   >
     <div
-      className="menu-item jsx-547246353 riipen riipen-menuitem"
+      className="menu-item jsx-1822691031 riipen riipen-menuitem"
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -24,10 +24,10 @@ exports[`<MenuItem> renders correct snapshot 1`] = `
         Array [
           "#747474",
           "Roboto, Helvetica, Arial, sans-serif",
-          "14px",
+          "16px",
           400,
           "0.00938em",
-          "20px",
+          "24px",
           10,
           20,
           "#1f71ae",

--- a/packages/riipen-ui/src/components/__snapshots__/MenuList.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/MenuList.test.jsx.snap
@@ -28,7 +28,7 @@ exports[`<MenuList> renders correct snapshot 1`] = `
           selected={false}
         >
           <div
-            className="menu-item jsx-547246353 riipen riipen-menuitem"
+            className="menu-item jsx-1822691031 riipen riipen-menuitem"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -41,10 +41,10 @@ exports[`<MenuList> renders correct snapshot 1`] = `
               Array [
                 "#747474",
                 "Roboto, Helvetica, Arial, sans-serif",
-                "14px",
+                "16px",
                 400,
                 "0.00938em",
-                "20px",
+                "24px",
                 10,
                 20,
                 "#1f71ae",

--- a/packages/riipen-ui/src/components/__snapshots__/Radio.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Radio.test.jsx.snap
@@ -48,12 +48,13 @@ exports[`<Radio> renders correct snapshot 1`] = `
             color="inherit"
             display="initial"
             gutter={false}
+            mobileBreakpoint="sm"
             textAlign="inherit"
             textTransform="inherit"
             variant="body1"
           >
             <p
-              className="jsx-1194261709 root color-inherit initial body1 align-inherit transform-inherit riipen riipen-typography jsx-835554889"
+              className="jsx-2087479458 root color-inherit initial mobile body1 align-inherit transform-inherit riipen riipen-typography jsx-835554889"
             >
               <JSXStyle
                 dynamic={
@@ -72,20 +73,20 @@ exports[`<Radio> renders correct snapshot 1`] = `
                   "#424242",
                   "Roboto, Helvetica, Arial, sans-serif",
                   400,
-                  "14px",
-                  "20px",
+                  "16px",
+                  "24px",
                   "0.00938em",
                   "#424242",
                   "Roboto, Helvetica, Arial, sans-serif",
                   400,
-                  "12px",
-                  "17px",
+                  "14px",
+                  "20px",
                   "0.01071em",
                   "#424242",
                   "Roboto, Helvetica, Arial, sans-serif",
                   400,
-                  "10px",
-                  "14px",
+                  "12px",
+                  "16px",
                   "0.01071em",
                   "#373737",
                   "Roboto, Helvetica, Arial, sans-serif",
@@ -97,7 +98,7 @@ exports[`<Radio> renders correct snapshot 1`] = `
                   "Roboto, Helvetica, Arial, sans-serif",
                   500,
                   "30px",
-                  "42px",
+                  "44px",
                   "-0.00833em",
                   "#373737",
                   "Roboto, Helvetica, Arial, sans-serif",
@@ -109,13 +110,13 @@ exports[`<Radio> renders correct snapshot 1`] = `
                   "Roboto, Helvetica, Arial, sans-serif",
                   400,
                   "20px",
-                  "30px",
+                  "28px",
                   "-0.00735em",
                   "#373737",
                   "Roboto, Helvetica, Arial, sans-serif",
                   400,
                   "16px",
-                  "23px",
+                  "24px",
                   "0rem",
                   "#000",
                   "#cccbcb",
@@ -134,9 +135,26 @@ exports[`<Radio> renders correct snapshot 1`] = `
                   300,
                   500,
                   400,
+                  600,
+                  "14px",
+                  "20px",
+                  "12px",
+                  "16px",
+                  "11px",
+                  "16px",
+                  "30px",
+                  "44px",
+                  "22px",
+                  "32px",
+                  "18px",
+                  "28px",
+                  "16px",
+                  "24px",
+                  "14px",
+                  "20px",
                 ]
               }
-              id="3194901921"
+              id="585098619"
             />
           </Typography>
         </withClasses(Typography)>

--- a/packages/riipen-ui/src/components/__snapshots__/RadioButton.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/RadioButton.test.jsx.snap
@@ -37,12 +37,13 @@ exports[`<RadioButton> renders correct snapshot 1`] = `
             component="span"
             display="initial"
             gutter={false}
+            mobileBreakpoint="sm"
             textAlign="inherit"
             textTransform="inherit"
             variant="body1"
           >
             <span
-              className="jsx-1194261709 root color-inherit initial body1 align-inherit transform-inherit riipen riipen-typography"
+              className="jsx-2087479458 root color-inherit initial mobile body1 align-inherit transform-inherit riipen riipen-typography"
             >
               <span
                 className="jsx-4157259141 content"
@@ -54,20 +55,20 @@ exports[`<RadioButton> renders correct snapshot 1`] = `
                   "#424242",
                   "Roboto, Helvetica, Arial, sans-serif",
                   400,
-                  "14px",
-                  "20px",
+                  "16px",
+                  "24px",
                   "0.00938em",
                   "#424242",
                   "Roboto, Helvetica, Arial, sans-serif",
                   400,
-                  "12px",
-                  "17px",
+                  "14px",
+                  "20px",
                   "0.01071em",
                   "#424242",
                   "Roboto, Helvetica, Arial, sans-serif",
                   400,
-                  "10px",
-                  "14px",
+                  "12px",
+                  "16px",
                   "0.01071em",
                   "#373737",
                   "Roboto, Helvetica, Arial, sans-serif",
@@ -79,7 +80,7 @@ exports[`<RadioButton> renders correct snapshot 1`] = `
                   "Roboto, Helvetica, Arial, sans-serif",
                   500,
                   "30px",
-                  "42px",
+                  "44px",
                   "-0.00833em",
                   "#373737",
                   "Roboto, Helvetica, Arial, sans-serif",
@@ -91,13 +92,13 @@ exports[`<RadioButton> renders correct snapshot 1`] = `
                   "Roboto, Helvetica, Arial, sans-serif",
                   400,
                   "20px",
-                  "30px",
+                  "28px",
                   "-0.00735em",
                   "#373737",
                   "Roboto, Helvetica, Arial, sans-serif",
                   400,
                   "16px",
-                  "23px",
+                  "24px",
                   "0rem",
                   "#000",
                   "#cccbcb",
@@ -116,9 +117,26 @@ exports[`<RadioButton> renders correct snapshot 1`] = `
                   300,
                   500,
                   400,
+                  600,
+                  "14px",
+                  "20px",
+                  "12px",
+                  "16px",
+                  "11px",
+                  "16px",
+                  "30px",
+                  "44px",
+                  "22px",
+                  "32px",
+                  "18px",
+                  "28px",
+                  "16px",
+                  "24px",
+                  "14px",
+                  "20px",
                 ]
               }
-              id="3194901921"
+              id="585098619"
             />
           </Typography>
         </withClasses(Typography)>

--- a/packages/riipen-ui/src/components/__snapshots__/RadioButtonGroup.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/RadioButtonGroup.test.jsx.snap
@@ -133,31 +133,43 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
         "typography": Object {
           "body1": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "14px",
+            "fontSize": "16px",
             "fontWeight": 400,
             "letterSpacing": "0.00938em",
-            "lineHeight": "20px",
+            "lineHeight": "24px",
+            "mobile": Object {
+              "fontSize": "14px",
+              "lineHeight": "20px",
+            },
           },
           "body2": Object {
+            "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
+            "fontSize": "14px",
+            "fontWeight": 400,
+            "letterSpacing": "0.01071em",
+            "lineHeight": "20px",
+            "mobile": Object {
+              "fontSize": "12px",
+              "lineHeight": "16px",
+            },
+          },
+          "body3": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "12px",
             "fontWeight": 400,
             "letterSpacing": "0.01071em",
-            "lineHeight": "17px",
-          },
-          "body3": Object {
-            "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "10px",
-            "fontWeight": 400,
-            "letterSpacing": "0.01071em",
-            "lineHeight": "14px",
+            "lineHeight": "16px",
+            "mobile": Object {
+              "fontSize": "11px",
+              "lineHeight": "16px",
+            },
           },
           "button": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "14px",
+            "fontSize": "13px",
             "fontWeight": 500,
             "letterSpacing": "0.02857em",
-            "lineHeight": 1.75,
+            "lineHeight": "20px",
           },
           "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
           "fontWeight": Object {
@@ -172,13 +184,21 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
             "fontWeight": 500,
             "letterSpacing": "-0.01562em",
             "lineHeight": "56px",
+            "mobile": Object {
+              "fontSize": "30px",
+              "lineHeight": "44px",
+            },
           },
           "h2": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "30px",
             "fontWeight": 500,
             "letterSpacing": "-0.00833em",
-            "lineHeight": "42px",
+            "lineHeight": "44px",
+            "mobile": Object {
+              "fontSize": "22px",
+              "lineHeight": "32px",
+            },
           },
           "h3": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
@@ -186,20 +206,32 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
             "fontWeight": 500,
             "letterSpacing": "0em",
             "lineHeight": "32px",
+            "mobile": Object {
+              "fontSize": "18px",
+              "lineHeight": "28px",
+            },
           },
           "h4": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "20px",
             "fontWeight": 400,
             "letterSpacing": "-0.00735em",
-            "lineHeight": "30px",
+            "lineHeight": "28px",
+            "mobile": Object {
+              "fontSize": "16px",
+              "lineHeight": "24px",
+            },
           },
           "h5": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "16px",
             "fontWeight": 400,
             "letterSpacing": "0rem",
-            "lineHeight": "23px",
+            "lineHeight": "24px",
+            "mobile": Object {
+              "fontSize": "14px",
+              "lineHeight": "20px",
+            },
           },
         },
         "zIndex": Object {
@@ -351,31 +383,43 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
           "typography": Object {
             "body1": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-              "fontSize": "14px",
+              "fontSize": "16px",
               "fontWeight": 400,
               "letterSpacing": "0.00938em",
-              "lineHeight": "20px",
+              "lineHeight": "24px",
+              "mobile": Object {
+                "fontSize": "14px",
+                "lineHeight": "20px",
+              },
             },
             "body2": Object {
+              "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
+              "fontSize": "14px",
+              "fontWeight": 400,
+              "letterSpacing": "0.01071em",
+              "lineHeight": "20px",
+              "mobile": Object {
+                "fontSize": "12px",
+                "lineHeight": "16px",
+              },
+            },
+            "body3": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
               "fontSize": "12px",
               "fontWeight": 400,
               "letterSpacing": "0.01071em",
-              "lineHeight": "17px",
-            },
-            "body3": Object {
-              "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-              "fontSize": "10px",
-              "fontWeight": 400,
-              "letterSpacing": "0.01071em",
-              "lineHeight": "14px",
+              "lineHeight": "16px",
+              "mobile": Object {
+                "fontSize": "11px",
+                "lineHeight": "16px",
+              },
             },
             "button": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-              "fontSize": "14px",
+              "fontSize": "13px",
               "fontWeight": 500,
               "letterSpacing": "0.02857em",
-              "lineHeight": 1.75,
+              "lineHeight": "20px",
             },
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontWeight": Object {
@@ -390,13 +434,21 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
               "fontWeight": 500,
               "letterSpacing": "-0.01562em",
               "lineHeight": "56px",
+              "mobile": Object {
+                "fontSize": "30px",
+                "lineHeight": "44px",
+              },
             },
             "h2": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
               "fontSize": "30px",
               "fontWeight": 500,
               "letterSpacing": "-0.00833em",
-              "lineHeight": "42px",
+              "lineHeight": "44px",
+              "mobile": Object {
+                "fontSize": "22px",
+                "lineHeight": "32px",
+              },
             },
             "h3": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
@@ -404,20 +456,32 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
               "fontWeight": 500,
               "letterSpacing": "0em",
               "lineHeight": "32px",
+              "mobile": Object {
+                "fontSize": "18px",
+                "lineHeight": "28px",
+              },
             },
             "h4": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
               "fontSize": "20px",
               "fontWeight": 400,
               "letterSpacing": "-0.00735em",
-              "lineHeight": "30px",
+              "lineHeight": "28px",
+              "mobile": Object {
+                "fontSize": "16px",
+                "lineHeight": "24px",
+              },
             },
             "h5": Object {
               "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
               "fontSize": "16px",
               "fontWeight": 400,
               "letterSpacing": "0rem",
-              "lineHeight": "23px",
+              "lineHeight": "24px",
+              "mobile": Object {
+                "fontSize": "14px",
+                "lineHeight": "20px",
+              },
             },
           },
           "zIndex": Object {
@@ -491,12 +555,13 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
                       component="span"
                       display="initial"
                       gutter={false}
+                      mobileBreakpoint="sm"
                       textAlign="inherit"
                       textTransform="inherit"
                       variant="body1"
                     >
                       <span
-                        className="jsx-1194261709 root color-inherit initial body1 align-inherit transform-inherit riipen riipen-typography"
+                        className="jsx-2087479458 root color-inherit initial mobile body1 align-inherit transform-inherit riipen riipen-typography"
                       >
                         <span
                           className="jsx-4157259141 content"
@@ -508,20 +573,20 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
                             "#424242",
                             "Roboto, Helvetica, Arial, sans-serif",
                             400,
-                            "14px",
-                            "20px",
+                            "16px",
+                            "24px",
                             "0.00938em",
                             "#424242",
                             "Roboto, Helvetica, Arial, sans-serif",
                             400,
-                            "12px",
-                            "17px",
+                            "14px",
+                            "20px",
                             "0.01071em",
                             "#424242",
                             "Roboto, Helvetica, Arial, sans-serif",
                             400,
-                            "10px",
-                            "14px",
+                            "12px",
+                            "16px",
                             "0.01071em",
                             "#373737",
                             "Roboto, Helvetica, Arial, sans-serif",
@@ -533,7 +598,7 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
                             "Roboto, Helvetica, Arial, sans-serif",
                             500,
                             "30px",
-                            "42px",
+                            "44px",
                             "-0.00833em",
                             "#373737",
                             "Roboto, Helvetica, Arial, sans-serif",
@@ -545,13 +610,13 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
                             "Roboto, Helvetica, Arial, sans-serif",
                             400,
                             "20px",
-                            "30px",
+                            "28px",
                             "-0.00735em",
                             "#373737",
                             "Roboto, Helvetica, Arial, sans-serif",
                             400,
                             "16px",
-                            "23px",
+                            "24px",
                             "0rem",
                             "#000",
                             "#cccbcb",
@@ -570,9 +635,26 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
                             300,
                             500,
                             400,
+                            600,
+                            "14px",
+                            "20px",
+                            "12px",
+                            "16px",
+                            "11px",
+                            "16px",
+                            "30px",
+                            "44px",
+                            "22px",
+                            "32px",
+                            "18px",
+                            "28px",
+                            "16px",
+                            "24px",
+                            "14px",
+                            "20px",
                           ]
                         }
-                        id="3194901921"
+                        id="585098619"
                       />
                     </Typography>
                   </withClasses(Typography)>

--- a/packages/riipen-ui/src/components/__snapshots__/Tab.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Tab.test.jsx.snap
@@ -141,31 +141,43 @@ exports[`<Tab> renders correct snapshot 1`] = `
         "typography": Object {
           "body1": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "14px",
+            "fontSize": "16px",
             "fontWeight": 400,
             "letterSpacing": "0.00938em",
-            "lineHeight": "20px",
+            "lineHeight": "24px",
+            "mobile": Object {
+              "fontSize": "14px",
+              "lineHeight": "20px",
+            },
           },
           "body2": Object {
+            "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
+            "fontSize": "14px",
+            "fontWeight": 400,
+            "letterSpacing": "0.01071em",
+            "lineHeight": "20px",
+            "mobile": Object {
+              "fontSize": "12px",
+              "lineHeight": "16px",
+            },
+          },
+          "body3": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "12px",
             "fontWeight": 400,
             "letterSpacing": "0.01071em",
-            "lineHeight": "17px",
-          },
-          "body3": Object {
-            "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "10px",
-            "fontWeight": 400,
-            "letterSpacing": "0.01071em",
-            "lineHeight": "14px",
+            "lineHeight": "16px",
+            "mobile": Object {
+              "fontSize": "11px",
+              "lineHeight": "16px",
+            },
           },
           "button": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
-            "fontSize": "14px",
+            "fontSize": "13px",
             "fontWeight": 500,
             "letterSpacing": "0.02857em",
-            "lineHeight": 1.75,
+            "lineHeight": "20px",
           },
           "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
           "fontWeight": Object {
@@ -180,13 +192,21 @@ exports[`<Tab> renders correct snapshot 1`] = `
             "fontWeight": 500,
             "letterSpacing": "-0.01562em",
             "lineHeight": "56px",
+            "mobile": Object {
+              "fontSize": "30px",
+              "lineHeight": "44px",
+            },
           },
           "h2": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "30px",
             "fontWeight": 500,
             "letterSpacing": "-0.00833em",
-            "lineHeight": "42px",
+            "lineHeight": "44px",
+            "mobile": Object {
+              "fontSize": "22px",
+              "lineHeight": "32px",
+            },
           },
           "h3": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
@@ -194,20 +214,32 @@ exports[`<Tab> renders correct snapshot 1`] = `
             "fontWeight": 500,
             "letterSpacing": "0em",
             "lineHeight": "32px",
+            "mobile": Object {
+              "fontSize": "18px",
+              "lineHeight": "28px",
+            },
           },
           "h4": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "20px",
             "fontWeight": 400,
             "letterSpacing": "-0.00735em",
-            "lineHeight": "30px",
+            "lineHeight": "28px",
+            "mobile": Object {
+              "fontSize": "16px",
+              "lineHeight": "24px",
+            },
           },
           "h5": Object {
             "fontFamily": "Roboto, Helvetica, Arial, sans-serif",
             "fontSize": "16px",
             "fontWeight": 400,
             "letterSpacing": "0rem",
-            "lineHeight": "23px",
+            "lineHeight": "24px",
+            "mobile": Object {
+              "fontSize": "14px",
+              "lineHeight": "20px",
+            },
           },
         },
         "zIndex": Object {
@@ -226,7 +258,7 @@ exports[`<Tab> renders correct snapshot 1`] = `
     <div
       aria-disabled={false}
       aria-pressed={false}
-      className="jsx-1189218266 root breakpoint secondary horizontal"
+      className="jsx-47801756 root breakpoint secondary horizontal"
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -258,7 +290,7 @@ exports[`<Tab> renders correct snapshot 1`] = `
           "#ddd",
           30,
           -5,
-          "12px",
+          "14px",
           5,
           15,
         ]

--- a/packages/riipen-ui/src/components/__snapshots__/TableCell.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/TableCell.test.jsx.snap
@@ -60,7 +60,7 @@ exports[`<TableCell> renders correct snapshot 1`] = `
                         textAlign="left"
                       >
                         <td
-                          className="jsx-1050854348 riipen riipen-tablecell"
+                          className="jsx-2965072238 riipen riipen-tablecell"
                           colSpan={1}
                           rowSpan={1}
                         />
@@ -68,10 +68,10 @@ exports[`<TableCell> renders correct snapshot 1`] = `
                           dynamic={
                             Array [
                               "Roboto, Helvetica, Arial, sans-serif",
-                              "12px",
+                              "14px",
                               400,
                               "0.01071em",
-                              "17px",
+                              "20px",
                               15,
                               "left",
                             ]

--- a/packages/riipen-ui/src/components/__snapshots__/TableHeaderCell.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/TableHeaderCell.test.jsx.snap
@@ -57,16 +57,16 @@ exports[`<TableHeaderCell> renders correct snapshot 1`] = `
                         textAlign="left"
                       >
                         <th
-                          className="jsx-3551769341 riipen riipen-tableheadercell"
+                          className="jsx-1948756155 riipen riipen-tableheadercell"
                         />
                         <JSXStyle
                           dynamic={
                             Array [
                               "Roboto, Helvetica, Arial, sans-serif",
-                              "14px",
+                              "16px",
                               400,
                               "0.00938em",
-                              "20px",
+                              "24px",
                               15,
                               "left",
                             ]

--- a/packages/riipen-ui/src/components/__snapshots__/Typography.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Typography.test.jsx.snap
@@ -12,12 +12,13 @@ exports[`<Typography> renders correct snapshot 1`] = `
     color="inherit"
     display="initial"
     gutter={false}
+    mobileBreakpoint="sm"
     textAlign="inherit"
     textTransform="inherit"
     variant="body1"
   >
     <p
-      className="jsx-1194261709 root color-inherit initial body1 align-inherit transform-inherit riipen riipen-typography"
+      className="jsx-2087479458 root color-inherit initial mobile body1 align-inherit transform-inherit riipen riipen-typography"
     />
     <JSXStyle
       dynamic={
@@ -25,20 +26,20 @@ exports[`<Typography> renders correct snapshot 1`] = `
           "#424242",
           "Roboto, Helvetica, Arial, sans-serif",
           400,
-          "14px",
-          "20px",
+          "16px",
+          "24px",
           "0.00938em",
           "#424242",
           "Roboto, Helvetica, Arial, sans-serif",
           400,
-          "12px",
-          "17px",
+          "14px",
+          "20px",
           "0.01071em",
           "#424242",
           "Roboto, Helvetica, Arial, sans-serif",
           400,
-          "10px",
-          "14px",
+          "12px",
+          "16px",
           "0.01071em",
           "#373737",
           "Roboto, Helvetica, Arial, sans-serif",
@@ -50,7 +51,7 @@ exports[`<Typography> renders correct snapshot 1`] = `
           "Roboto, Helvetica, Arial, sans-serif",
           500,
           "30px",
-          "42px",
+          "44px",
           "-0.00833em",
           "#373737",
           "Roboto, Helvetica, Arial, sans-serif",
@@ -62,13 +63,13 @@ exports[`<Typography> renders correct snapshot 1`] = `
           "Roboto, Helvetica, Arial, sans-serif",
           400,
           "20px",
-          "30px",
+          "28px",
           "-0.00735em",
           "#373737",
           "Roboto, Helvetica, Arial, sans-serif",
           400,
           "16px",
-          "23px",
+          "24px",
           "0rem",
           "#000",
           "#cccbcb",
@@ -87,9 +88,26 @@ exports[`<Typography> renders correct snapshot 1`] = `
           300,
           500,
           400,
+          600,
+          "14px",
+          "20px",
+          "12px",
+          "16px",
+          "11px",
+          "16px",
+          "30px",
+          "44px",
+          "22px",
+          "32px",
+          "18px",
+          "28px",
+          "16px",
+          "24px",
+          "14px",
+          "20px",
         ]
       }
-      id="3194901921"
+      id="585098619"
     />
   </Typography>
 </withClasses(Typography)>

--- a/packages/riipen-ui/src/themes/default.js
+++ b/packages/riipen-ui/src/themes/default.js
@@ -135,29 +135,41 @@ export default {
     body1: {
       fontFamily: "Roboto, Helvetica, Arial, sans-serif",
       fontWeight: 400,
-      fontSize: "14px",
-      lineHeight: "20px",
-      letterSpacing: "0.00938em"
+      fontSize: "16px",
+      lineHeight: "24px",
+      letterSpacing: "0.00938em",
+      mobile: {
+        fontSize: "14px",
+        lineHeight: "20px",
+      }
     },
     body2: {
       fontFamily: "Roboto, Helvetica, Arial, sans-serif",
       fontWeight: 400,
-      fontSize: "12px",
-      lineHeight: "17px",
-      letterSpacing: "0.01071em"
+      fontSize: "14px",
+      lineHeight: "20px",
+      letterSpacing: "0.01071em",
+      mobile: {
+        fontSize: "12px",
+        lineHeight: "16px",
+      }
     },
     body3: {
       fontFamily: "Roboto, Helvetica, Arial, sans-serif",
       fontWeight: 400,
-      fontSize: "10px",
-      lineHeight: "14px",
-      letterSpacing: "0.01071em"
+      fontSize: "12px",
+      lineHeight: "16px",
+      letterSpacing: "0.01071em",
+      mobile: {
+        fontSize: "11px",
+        lineHeight: "16px",
+      }
     },
     button: {
       fontFamily: "Roboto, Helvetica, Arial, sans-serif",
       fontWeight: 500,
-      fontSize: "14px",
-      lineHeight: 1.75,
+      fontSize: "13px",
+      lineHeight: "20px",
       letterSpacing: "0.02857em"
     },
     fontFamily: "Roboto, Helvetica, Arial, sans-serif",
@@ -172,36 +184,56 @@ export default {
       fontWeight: 500,
       fontSize: "40px",
       lineHeight: "56px",
-      letterSpacing: "-0.01562em"
+      letterSpacing: "-0.01562em",
+      mobile: {
+        fontSize: "30px",
+        lineHeight: "44px",
+      }
     },
     h2: {
       fontFamily: "Roboto, Helvetica, Arial, sans-serif",
       fontWeight: 500,
       fontSize: "30px",
-      lineHeight: "42px",
-      letterSpacing: "-0.00833em"
+      lineHeight: "44px",
+      letterSpacing: "-0.00833em",
+      mobile: {
+        fontSize: "22px",
+        lineHeight: "32px",
+      }
     },
     h3: {
       fontFamily: "Roboto, Helvetica, Arial, sans-serif",
       fontWeight: 500,
       fontSize: "22px",
       lineHeight: "32px",
-      letterSpacing: "0em"
+      letterSpacing: "0em",
+      mobile: {
+        fontSize: "18px",
+        lineHeight: "28px",
+      }
     },
     h4: {
       fontFamily: "Roboto, Helvetica, Arial, sans-serif",
       fontWeight: 400,
       fontSize: "20px",
-      lineHeight: "30px",
-      letterSpacing: "-0.00735em"
+      lineHeight: "28px",
+      letterSpacing: "-0.00735em",
+      mobile: {
+        fontSize: "16px",
+        lineHeight: "24px",
+      }
     },
     h5: {
       fontFamily: "Roboto, Helvetica, Arial, sans-serif",
       fontWeight: 400,
       fontSize: "16px",
-      lineHeight: "23px",
-      letterSpacing: "0rem"
-    }
+      lineHeight: "24px",
+      letterSpacing: "0rem",
+      mobile: {
+        fontSize: "14px",
+        lineHeight: "20px",
+      }
+    },
   },
   zIndex: {
     zero: 0,

--- a/packages/riipen-ui/src/themes/default.js
+++ b/packages/riipen-ui/src/themes/default.js
@@ -140,7 +140,7 @@ export default {
       letterSpacing: "0.00938em",
       mobile: {
         fontSize: "14px",
-        lineHeight: "20px",
+        lineHeight: "20px"
       }
     },
     body2: {
@@ -151,7 +151,7 @@ export default {
       letterSpacing: "0.01071em",
       mobile: {
         fontSize: "12px",
-        lineHeight: "16px",
+        lineHeight: "16px"
       }
     },
     body3: {
@@ -162,7 +162,7 @@ export default {
       letterSpacing: "0.01071em",
       mobile: {
         fontSize: "11px",
-        lineHeight: "16px",
+        lineHeight: "16px"
       }
     },
     button: {
@@ -187,7 +187,7 @@ export default {
       letterSpacing: "-0.01562em",
       mobile: {
         fontSize: "30px",
-        lineHeight: "44px",
+        lineHeight: "44px"
       }
     },
     h2: {
@@ -198,7 +198,7 @@ export default {
       letterSpacing: "-0.00833em",
       mobile: {
         fontSize: "22px",
-        lineHeight: "32px",
+        lineHeight: "32px"
       }
     },
     h3: {
@@ -209,7 +209,7 @@ export default {
       letterSpacing: "0em",
       mobile: {
         fontSize: "18px",
-        lineHeight: "28px",
+        lineHeight: "28px"
       }
     },
     h4: {
@@ -220,7 +220,7 @@ export default {
       letterSpacing: "-0.00735em",
       mobile: {
         fontSize: "16px",
-        lineHeight: "24px",
+        lineHeight: "24px"
       }
     },
     h5: {
@@ -231,9 +231,9 @@ export default {
       letterSpacing: "0rem",
       mobile: {
         fontSize: "14px",
-        lineHeight: "20px",
+        lineHeight: "20px"
       }
-    },
+    }
   },
   zIndex: {
     zero: 0,


### PR DESCRIPTION
https://riipen.atlassian.net/browse/PLT-8331

## Description
Add mobile Typography sizes and line-height, update `Typography` component to use these sizes on mobile resolution
Sizes: https://www.figma.com/file/RYjBuSngR9y0L5PeDZp6b2/01-Components?node-id=1725%3A373664

## Notes

## Screenshots

## Where to Start
