### PR TITLE
Add word break prop to typography

### DIFF
--- a/packages/riipen-ui-docs/src/pages/components/typography/WordBreak.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/typography/WordBreak.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+import Typography from "riipen-ui/components/Typography";
+
+export default function TextTransform() {
+  return (
+    <div>
+      <Typography wordBreak="break-all" gutter>
+        {"breakall".repeat(30)}
+      </Typography>
+      <Typography wordBreak="break-word" gutter>
+        {"breakword".repeat(30)}
+      </Typography>
+      <Typography wordBreak="normal" gutter>
+        {"normal".repeat(30)}
+      </Typography>
+    </div>
+  );
+}

--- a/packages/riipen-ui-docs/src/pages/components/typography/typography.md
+++ b/packages/riipen-ui-docs/src/pages/components/typography/typography.md
@@ -7,7 +7,7 @@ set of type sizes that work well together along with the layout grid.
 
 ## General
 
-The *Roboto* font will **not** be automatically loaded by Riipen-UI.
+The _Roboto_ font will **not** be automatically loaded by Riipen-UI.
 The developer is responsible for loading all fonts used in their application.
 
 ## Roboto Font CDN
@@ -15,7 +15,10 @@ The developer is responsible for loading all fonts used in their application.
 Shown below is a sample link markup used to load the Roboto font from a CDN:
 
 ```html
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
+<link
+  rel="stylesheet"
+  href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
+/>
 ```
 
 ## Component
@@ -36,15 +39,21 @@ You can also use the CSS native "inherit" for a wider range of colors.
 
 {{"demo": "pages/components/typography/TextTransform.js"}}
 
+## Word Break
+
+{{"demo": "pages/components/typography/WordBreak.js"}}
+
 ## Changing the semantic element
 
 You can change the underlying element for a one time occasion with the `component` property:
 
 ```jsx
-{/* There is already an h1 in the page, let's not duplicate it. */}
+{
+  /* There is already an h1 in the page, let's not duplicate it. */
+}
 <Typography variant="h1" component="h2">
   h1. Heading
-</Typography>
+</Typography>;
 ```
 
 ## Accessibility

--- a/packages/riipen-ui/src/components/Typography.jsx
+++ b/packages/riipen-ui/src/components/Typography.jsx
@@ -116,7 +116,12 @@ class Typography extends React.Component {
       "body2",
       "body3",
       "inherit"
-    ])
+    ]),
+
+    /**
+     * Set the word break on the component.
+     */
+    wordBreak: PropTypes.oneOf(["break-all", "break-word", "normal"])
   };
 
   static defaultProps = {
@@ -127,7 +132,8 @@ class Typography extends React.Component {
     mobileBreakpoint: "sm",
     textAlign: "inherit",
     textTransform: "inherit",
-    variant: "body1"
+    variant: "body1",
+    wordBreak: "normal"
   };
 
   static contextType = ThemeContext;
@@ -144,7 +150,8 @@ class Typography extends React.Component {
       mobileBreakpoint,
       textAlign,
       textTransform,
-      variant
+      variant,
+      wordBreak
     } = this.props;
 
     const theme = this.context;
@@ -159,6 +166,7 @@ class Typography extends React.Component {
       variant,
       `align-${textAlign}`,
       `transform-${textTransform}`,
+      `word-break-${wordBreak}`,
       classes
     );
 
@@ -325,6 +333,16 @@ class Typography extends React.Component {
           }
           .transform-lowercase {
             text-transform: lowercase;
+          }
+
+          .word-break-break-all {
+            word-break: break-all;
+          }
+          .word-break-break-word {
+            word-break: break-word;
+          }
+          .word-break-normal {
+            word-break: normal;
           }
 
           @media (max-width: ${theme.breakpoints[mobileBreakpoint]}px) {

--- a/packages/riipen-ui/src/components/Typography.test.jsx
+++ b/packages/riipen-ui/src/components/Typography.test.jsx
@@ -309,4 +309,28 @@ describe("<Typography>", () => {
       expect(errors).toHaveBeenCalled();
     });
   });
+
+  describe("wordBreak prop", () => {
+    it("sets wordBreak class given a valid wordBreak prop", () => {
+      const wordBreak = "normal";
+
+      const wrapper = mount(<Typography wordBreak={wordBreak} />);
+
+      expect(
+        wrapper
+          .find("Typography")
+          .childAt(0)
+          .hasClass(`word-break-${wordBreak}`)
+      ).toEqual(true);
+    });
+
+    it("gives an error given an invalid wordBreak prop", () => {
+      const wordBreak = "invalid";
+      const errors = jest.spyOn(console, "error").mockImplementation();
+
+      mount(<Typography wordBreak={wordBreak} />);
+
+      expect(errors).toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/riipen-ui/src/components/__snapshots__/Breadcrumbs.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Breadcrumbs.test.jsx.snap
@@ -30,9 +30,10 @@ exports[`<Breadcrumbs> renders correct snapshot 1`] = `
         textAlign="inherit"
         textTransform="inherit"
         variant="body1"
+        wordBreak="normal"
       >
         <nav
-          className="jsx-2087479458 root color-inherit initial mobile body1 align-inherit transform-inherit riipen riipen-typography"
+          className="jsx-2345121370 root color-inherit initial mobile body1 align-inherit transform-inherit word-break-normal riipen riipen-typography"
         >
           <ol
             className="jsx-2183045356 riipen riipen-breadcrumbs"
@@ -134,7 +135,7 @@ exports[`<Breadcrumbs> renders correct snapshot 1`] = `
               "20px",
             ]
           }
-          id="585098619"
+          id="3367936398"
         />
       </Typography>
     </withClasses(Typography)>

--- a/packages/riipen-ui/src/components/__snapshots__/Checkbox.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Checkbox.test.jsx.snap
@@ -273,9 +273,10 @@ exports[`<Checkbox> renders correct snapshot 1`] = `
             textAlign="inherit"
             textTransform="inherit"
             variant="body1"
+            wordBreak="normal"
           >
             <p
-              className="jsx-2087479458 root color-inherit initial mobile body1 align-inherit transform-inherit riipen riipen-typography"
+              className="jsx-2345121370 root color-inherit initial mobile body1 align-inherit transform-inherit word-break-normal riipen riipen-typography"
             />
             <JSXStyle
               dynamic={
@@ -364,7 +365,7 @@ exports[`<Checkbox> renders correct snapshot 1`] = `
                   "20px",
                 ]
               }
-              id="585098619"
+              id="3367936398"
             />
           </Typography>
         </withClasses(Typography)>

--- a/packages/riipen-ui/src/components/__snapshots__/InputHint.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/InputHint.test.jsx.snap
@@ -518,9 +518,10 @@ exports[`<InputHint> renders correct snapshot 1`] = `
             textAlign="inherit"
             textTransform="inherit"
             variant="body2"
+            wordBreak="normal"
           >
             <p
-              className="jsx-2087479458 root color-inherit initial mobile body2 align-inherit transform-inherit riipen riipen-typography"
+              className="jsx-2345121370 root color-inherit initial mobile body2 align-inherit transform-inherit word-break-normal riipen riipen-typography"
             />
             <JSXStyle
               dynamic={
@@ -609,7 +610,7 @@ exports[`<InputHint> renders correct snapshot 1`] = `
                   "20px",
                 ]
               }
-              id="585098619"
+              id="3367936398"
             />
           </Typography>
         </withClasses(Typography)>

--- a/packages/riipen-ui/src/components/__snapshots__/Radio.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Radio.test.jsx.snap
@@ -52,9 +52,10 @@ exports[`<Radio> renders correct snapshot 1`] = `
             textAlign="inherit"
             textTransform="inherit"
             variant="body1"
+            wordBreak="normal"
           >
             <p
-              className="jsx-2087479458 root color-inherit initial mobile body1 align-inherit transform-inherit riipen riipen-typography jsx-835554889"
+              className="jsx-2345121370 root color-inherit initial mobile body1 align-inherit transform-inherit word-break-normal riipen riipen-typography jsx-835554889"
             >
               <JSXStyle
                 dynamic={
@@ -154,7 +155,7 @@ exports[`<Radio> renders correct snapshot 1`] = `
                   "20px",
                 ]
               }
-              id="585098619"
+              id="3367936398"
             />
           </Typography>
         </withClasses(Typography)>

--- a/packages/riipen-ui/src/components/__snapshots__/RadioButton.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/RadioButton.test.jsx.snap
@@ -41,9 +41,10 @@ exports[`<RadioButton> renders correct snapshot 1`] = `
             textAlign="inherit"
             textTransform="inherit"
             variant="body1"
+            wordBreak="normal"
           >
             <span
-              className="jsx-2087479458 root color-inherit initial mobile body1 align-inherit transform-inherit riipen riipen-typography"
+              className="jsx-2345121370 root color-inherit initial mobile body1 align-inherit transform-inherit word-break-normal riipen riipen-typography"
             >
               <span
                 className="jsx-4157259141 content"
@@ -136,7 +137,7 @@ exports[`<RadioButton> renders correct snapshot 1`] = `
                   "20px",
                 ]
               }
-              id="585098619"
+              id="3367936398"
             />
           </Typography>
         </withClasses(Typography)>

--- a/packages/riipen-ui/src/components/__snapshots__/RadioButtonGroup.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/RadioButtonGroup.test.jsx.snap
@@ -559,9 +559,10 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
                       textAlign="inherit"
                       textTransform="inherit"
                       variant="body1"
+                      wordBreak="normal"
                     >
                       <span
-                        className="jsx-2087479458 root color-inherit initial mobile body1 align-inherit transform-inherit riipen riipen-typography"
+                        className="jsx-2345121370 root color-inherit initial mobile body1 align-inherit transform-inherit word-break-normal riipen riipen-typography"
                       >
                         <span
                           className="jsx-4157259141 content"
@@ -654,7 +655,7 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
                             "20px",
                           ]
                         }
-                        id="585098619"
+                        id="3367936398"
                       />
                     </Typography>
                   </withClasses(Typography)>

--- a/packages/riipen-ui/src/components/__snapshots__/Typography.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Typography.test.jsx.snap
@@ -16,9 +16,10 @@ exports[`<Typography> renders correct snapshot 1`] = `
     textAlign="inherit"
     textTransform="inherit"
     variant="body1"
+    wordBreak="normal"
   >
     <p
-      className="jsx-2087479458 root color-inherit initial mobile body1 align-inherit transform-inherit riipen riipen-typography"
+      className="jsx-2345121370 root color-inherit initial mobile body1 align-inherit transform-inherit word-break-normal riipen riipen-typography"
     />
     <JSXStyle
       dynamic={
@@ -107,7 +108,7 @@ exports[`<Typography> renders correct snapshot 1`] = `
           "20px",
         ]
       }
-      id="585098619"
+      id="3367936398"
     />
   </Typography>
 </withClasses(Typography)>


### PR DESCRIPTION
## Description
Add wordBreak prop to Typography.
Update tests and documents.

## Notes

## Screenshots
![Screenshot 2021-12-02 at 16-34-03 Typography Riipen UI](https://user-images.githubusercontent.com/10818279/144525234-2903123d-fefb-4561-9562-2b58ab03ed03.png)


## Where to Start
components/Typography