### PR TITLE
Make wordBreak optional

### DIFF
--- a/packages/riipen-ui/src/components/Typography.jsx
+++ b/packages/riipen-ui/src/components/Typography.jsx
@@ -132,8 +132,7 @@ class Typography extends React.Component {
     mobileBreakpoint: "sm",
     textAlign: "inherit",
     textTransform: "inherit",
-    variant: "body1",
-    wordBreak: "normal"
+    variant: "body1"
   };
 
   static contextType = ThemeContext;
@@ -166,7 +165,7 @@ class Typography extends React.Component {
       variant,
       `align-${textAlign}`,
       `transform-${textTransform}`,
-      `word-break-${wordBreak}`,
+      wordBreak ? `word-break-${wordBreak}` : null,
       classes
     );
 

--- a/packages/riipen-ui/src/components/__snapshots__/Breadcrumbs.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Breadcrumbs.test.jsx.snap
@@ -30,10 +30,9 @@ exports[`<Breadcrumbs> renders correct snapshot 1`] = `
         textAlign="inherit"
         textTransform="inherit"
         variant="body1"
-        wordBreak="normal"
       >
         <nav
-          className="jsx-2345121370 root color-inherit initial mobile body1 align-inherit transform-inherit word-break-normal riipen riipen-typography"
+          className="jsx-2345121370 root color-inherit initial mobile body1 align-inherit transform-inherit riipen riipen-typography"
         >
           <ol
             className="jsx-2183045356 riipen riipen-breadcrumbs"

--- a/packages/riipen-ui/src/components/__snapshots__/Checkbox.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Checkbox.test.jsx.snap
@@ -273,10 +273,9 @@ exports[`<Checkbox> renders correct snapshot 1`] = `
             textAlign="inherit"
             textTransform="inherit"
             variant="body1"
-            wordBreak="normal"
           >
             <p
-              className="jsx-2345121370 root color-inherit initial mobile body1 align-inherit transform-inherit word-break-normal riipen riipen-typography"
+              className="jsx-2345121370 root color-inherit initial mobile body1 align-inherit transform-inherit riipen riipen-typography"
             />
             <JSXStyle
               dynamic={

--- a/packages/riipen-ui/src/components/__snapshots__/InputHint.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/InputHint.test.jsx.snap
@@ -518,10 +518,9 @@ exports[`<InputHint> renders correct snapshot 1`] = `
             textAlign="inherit"
             textTransform="inherit"
             variant="body2"
-            wordBreak="normal"
           >
             <p
-              className="jsx-2345121370 root color-inherit initial mobile body2 align-inherit transform-inherit word-break-normal riipen riipen-typography"
+              className="jsx-2345121370 root color-inherit initial mobile body2 align-inherit transform-inherit riipen riipen-typography"
             />
             <JSXStyle
               dynamic={

--- a/packages/riipen-ui/src/components/__snapshots__/Radio.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Radio.test.jsx.snap
@@ -52,10 +52,9 @@ exports[`<Radio> renders correct snapshot 1`] = `
             textAlign="inherit"
             textTransform="inherit"
             variant="body1"
-            wordBreak="normal"
           >
             <p
-              className="jsx-2345121370 root color-inherit initial mobile body1 align-inherit transform-inherit word-break-normal riipen riipen-typography jsx-835554889"
+              className="jsx-2345121370 root color-inherit initial mobile body1 align-inherit transform-inherit riipen riipen-typography jsx-835554889"
             >
               <JSXStyle
                 dynamic={

--- a/packages/riipen-ui/src/components/__snapshots__/RadioButton.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/RadioButton.test.jsx.snap
@@ -41,10 +41,9 @@ exports[`<RadioButton> renders correct snapshot 1`] = `
             textAlign="inherit"
             textTransform="inherit"
             variant="body1"
-            wordBreak="normal"
           >
             <span
-              className="jsx-2345121370 root color-inherit initial mobile body1 align-inherit transform-inherit word-break-normal riipen riipen-typography"
+              className="jsx-2345121370 root color-inherit initial mobile body1 align-inherit transform-inherit riipen riipen-typography"
             >
               <span
                 className="jsx-4157259141 content"

--- a/packages/riipen-ui/src/components/__snapshots__/RadioButtonGroup.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/RadioButtonGroup.test.jsx.snap
@@ -559,10 +559,9 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
                       textAlign="inherit"
                       textTransform="inherit"
                       variant="body1"
-                      wordBreak="normal"
                     >
                       <span
-                        className="jsx-2345121370 root color-inherit initial mobile body1 align-inherit transform-inherit word-break-normal riipen riipen-typography"
+                        className="jsx-2345121370 root color-inherit initial mobile body1 align-inherit transform-inherit riipen riipen-typography"
                       >
                         <span
                           className="jsx-4157259141 content"

--- a/packages/riipen-ui/src/components/__snapshots__/Typography.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Typography.test.jsx.snap
@@ -16,10 +16,9 @@ exports[`<Typography> renders correct snapshot 1`] = `
     textAlign="inherit"
     textTransform="inherit"
     variant="body1"
-    wordBreak="normal"
   >
     <p
-      className="jsx-2345121370 root color-inherit initial mobile body1 align-inherit transform-inherit word-break-normal riipen riipen-typography"
+      className="jsx-2345121370 root color-inherit initial mobile body1 align-inherit transform-inherit riipen riipen-typography"
     />
     <JSXStyle
       dynamic={


### PR DESCRIPTION
## Description
Update defaultProps to make wordBreak optional to debloat things.

## Where to Start
packages/riipen-ui/src/components/Typography.jsx 