### PR TITLE
[PLT-8331] Fix `RadioButton` typography on desktop

### DIFF
--- a/packages/riipen-ui/src/components/RadioButton.jsx
+++ b/packages/riipen-ui/src/components/RadioButton.jsx
@@ -23,7 +23,7 @@ const RadioButton = ({
 
   let typographyVariant;
   if (size === "small") {
-    typographyVariant = "body2";
+    typographyVariant = "body3";
   } else if (size === "large") {
     typographyVariant = "h5";
   }


### PR DESCRIPTION
## Description
Change RadioButton typography variant to be `body3` since some desktop sizes increased and this is equivalent to the previous `body2` size

## Notes

## Screenshots
![Screen Shot 2021-12-17 at 7 11 36 PM](https://user-images.githubusercontent.com/16536701/146621488-e4b42d9f-a884-461d-b5bf-9f447e9bc85f.png)

## Where to Start
