### PR TITLE
[PLT-9020] Wrap AccordionDetails in AccordionContext

### DIFF
--- a/packages/riipen-ui/src/components/Accordion.jsx
+++ b/packages/riipen-ui/src/components/Accordion.jsx
@@ -14,7 +14,6 @@ const Accordion = props => {
     classes,
     defaultExpanded,
     disabled,
-    provideContextToChildren,
     ...other
   } = props;
 
@@ -49,26 +48,8 @@ const Accordion = props => {
       )}
       {...other}
     >
-      {provideContextToChildren && (
-        <AccordionContext.Provider value={contextValue}>
-          {summary}
-          <Collapse in={expanded}>
-            <div
-              aria-labelledby={summary.props.id}
-              id={summary.props["aria-controls"]}
-            >
-              {children}
-            </div>
-          </Collapse>
-        </AccordionContext.Provider>
-      )}
-
-      {!provideContextToChildren && (
-        <AccordionContext.Provider value={contextValue}>
-          {summary}
-        </AccordionContext.Provider>
-      )}
-      {!provideContextToChildren && (
+      <AccordionContext.Provider value={contextValue}>
+        {summary}
         <Collapse in={expanded}>
           <div
             aria-labelledby={summary.props.id}
@@ -77,7 +58,7 @@ const Accordion = props => {
             {children}
           </div>
         </Collapse>
-      )}
+      </AccordionContext.Provider>
 
       <style jsx>{`
         .root {
@@ -130,19 +111,13 @@ Accordion.propTypes = {
   /**
    * If `true`, the accordion will be displayed in a disabled state.
    */
-  disabled: PropTypes.bool,
-
-  /**
-   * If `true`, the accordion will wrap its children in the AccordionContext, so that the children have access to the context.
-   */
-  provideContextToChildren: PropTypes.bool
+  disabled: PropTypes.bool
 };
 
 Accordion.defaultProps = {
   classes: [],
   defaultExpanded: false,
-  disabled: false,
-  provideContextToChildren: false
+  disabled: false
 };
 
 Accordion.displayName = "Accordion";

--- a/packages/riipen-ui/src/components/Accordion.jsx
+++ b/packages/riipen-ui/src/components/Accordion.jsx
@@ -14,6 +14,7 @@ const Accordion = props => {
     classes,
     defaultExpanded,
     disabled,
+    provideContextToChildren,
     ...other
   } = props;
 
@@ -48,17 +49,35 @@ const Accordion = props => {
       )}
       {...other}
     >
-      <AccordionContext.Provider value={contextValue}>
-        {summary}
-      </AccordionContext.Provider>
-      <Collapse in={expanded}>
-        <div
-          aria-labelledby={summary.props.id}
-          id={summary.props["aria-controls"]}
-        >
-          {children}
-        </div>
-      </Collapse>
+      {provideContextToChildren && (
+        <AccordionContext.Provider value={contextValue}>
+          {summary}
+          <Collapse in={expanded}>
+            <div
+              aria-labelledby={summary.props.id}
+              id={summary.props["aria-controls"]}
+            >
+              {children}
+            </div>
+          </Collapse>
+        </AccordionContext.Provider>
+      )}
+
+      {!provideContextToChildren && (
+        <AccordionContext.Provider value={contextValue}>
+          {summary}
+        </AccordionContext.Provider>
+      )}
+      {!provideContextToChildren && (
+        <Collapse in={expanded}>
+          <div
+            aria-labelledby={summary.props.id}
+            id={summary.props["aria-controls"]}
+          >
+            {children}
+          </div>
+        </Collapse>
+      )}
 
       <style jsx>{`
         .root {
@@ -111,13 +130,19 @@ Accordion.propTypes = {
   /**
    * If `true`, the accordion will be displayed in a disabled state.
    */
-  disabled: PropTypes.bool
+  disabled: PropTypes.bool,
+
+  /**
+   * If `true`, the accordion will wrap its children in the AccordionContext, so that the children have access to the context.
+   */
+  provideContextToChildren: PropTypes.bool
 };
 
 Accordion.defaultProps = {
   classes: [],
   defaultExpanded: false,
-  disabled: false
+  disabled: false,
+  provideContextToChildren: false
 };
 
 Accordion.displayName = "Accordion";

--- a/packages/riipen-ui/src/components/__snapshots__/Accordion.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Accordion.test.jsx.snap
@@ -5,6 +5,7 @@ exports[`<Accordion> renders correct snapshot 1`] = `
   classes={Array []}
   defaultExpanded={false}
   disabled={false}
+  provideContextToChildren={false}
 >
   <div
     className="jsx-839250457 root"

--- a/packages/riipen-ui/src/components/__snapshots__/Accordion.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Accordion.test.jsx.snap
@@ -5,7 +5,6 @@ exports[`<Accordion> renders correct snapshot 1`] = `
   classes={Array []}
   defaultExpanded={false}
   disabled={false}
-  provideContextToChildren={false}
 >
   <div
     className="jsx-839250457 root"


### PR DESCRIPTION
## Description
We want to enable AccordionDetails to be able to
access the Accordion context so that AccordionDetails
and its children can know whether or not their
Accordion is expanded. This can be used so that
we only load data when the accordion is expanded.
## Notes


## Screenshots

## Where to Start
