### PR TITLE
Add text transform to tabs

### DIFF
--- a/packages/riipen-ui-docs/src/pages/components/tabs/TextTransform.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/tabs/TextTransform.jsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+import Tabs from "riipen-ui/components/Tabs";
+import Tab from "riipen-ui/components/Tab";
+
+export default function TextTransform() {
+  const style = {
+    backgroundColor: "#fff"
+  };
+
+  const [state, setState] = React.useState({
+    value: "one"
+  });
+
+  const handleChange = (e, value) => {
+    setState({ ...state, value });
+  };
+
+  return (
+    <div>
+      <div style={style}>
+        <Tabs
+          onChange={handleChange}
+          value={state.value}
+          variant="fullWidth"
+          textTransform="lowercase"
+        >
+          <Tab label="Item one" value="one" />
+          <Tab label="Item two" value="two" />
+          <Tab label="Item three" value="three" />
+        </Tabs>
+      </div>
+    </div>
+  );
+}

--- a/packages/riipen-ui-docs/src/pages/components/tabs/tabs.md
+++ b/packages/riipen-ui-docs/src/pages/components/tabs/tabs.md
@@ -42,6 +42,12 @@ You can set the breakpoint to display the horizontal tab mobile styling with the
 
 {{"demo": "pages/components/tabs/Breakpoint.js"}}
 
+## Text Transform
+
+You can set the tab label casing with the `textTransform` prop.
+
+{{"demo": "pages/components/tabs/TextTransform.js"}}
+
 ## Forcing Active Display
 
 Tabs can be forced to display active with the `displayActive` tab prop.

--- a/packages/riipen-ui/src/components/Tab.jsx
+++ b/packages/riipen-ui/src/components/Tab.jsx
@@ -18,6 +18,7 @@ const Tab = props => {
     label,
     onClick,
     orientation,
+    textTransform,
     theme,
     value
   } = props;
@@ -110,7 +111,7 @@ const Tab = props => {
           letter-spacing: 2px;
           line-height: ${theme.typography.body2.lineHeight};
           text-decoration: none;
-          text-transform: uppercase;
+          text-transform: ${textTransform};
           width: 100%;
         }
 
@@ -185,7 +186,8 @@ Tab.defaultProps = {
   color: "secondary",
   disabled: false,
   fullWidth: false,
-  orientation: "horizontal"
+  orientation: "horizontal",
+  textTransform: "uppercase"
 };
 
 Tab.propTypes = {
@@ -246,6 +248,16 @@ Tab.propTypes = {
    * The indicator orientation.
    */
   orientation: PropTypes.oneOf(["horizontal", "vertical"]),
+
+  /**
+   * Set the text-transform on the tabs.
+   */
+  textTransform: PropTypes.oneOf([
+    "inherit",
+    "capitalize",
+    "uppercase",
+    "lowercase"
+  ]),
 
   /**
    * @ignore

--- a/packages/riipen-ui/src/components/Tab.test.jsx
+++ b/packages/riipen-ui/src/components/Tab.test.jsx
@@ -38,6 +38,7 @@ describe("<Tab>", () => {
       expect(wrapper.find("Tab").props().disabled).toEqual(false);
       expect(wrapper.find("Tab").props().fullWidth).toEqual(false);
       expect(wrapper.find("Tab").props().orientation).toEqual("horizontal");
+      expect(wrapper.find("Tab").props().textTransform).toEqual("uppercase");
     });
   });
 
@@ -373,6 +374,17 @@ describe("<Tab>", () => {
           .childAt(0)
           .hasClass("focusVisible")
       ).toBeFalsy();
+    });
+  });
+
+  describe("textTransform prop", () => {
+    it("gives an error when given an invalid textTransform", () => {
+      const errors = jest.spyOn(console, "error").mockImplementation();
+      const textTransform = "upright";
+
+      mount(<Tab textTransform={textTransform} value />);
+
+      expect(errors).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/riipen-ui/src/components/Tabs.jsx
+++ b/packages/riipen-ui/src/components/Tabs.jsx
@@ -49,6 +49,16 @@ class Tabs extends React.Component {
     orientation: PropTypes.oneOf(["horizontal", "vertical"]),
 
     /**
+     * Set the text-transform on the tabs.
+     */
+    textTransform: PropTypes.oneOf([
+      "inherit",
+      "capitalize",
+      "uppercase",
+      "lowercase"
+    ]),
+
+    /**
      * The value of the currently selected `Tab`.
      */
     value: PropTypes.any,
@@ -68,6 +78,7 @@ class Tabs extends React.Component {
     color: "secondary",
     component: "div",
     orientation: "horizontal",
+    textTransform: "uppercase",
     variant: "standard"
   };
 
@@ -87,6 +98,7 @@ class Tabs extends React.Component {
       color,
       component: Component,
       orientation,
+      textTransform,
       value,
       variant
     } = this.props;
@@ -104,7 +116,8 @@ class Tabs extends React.Component {
         color,
         fullWidth: variant === "fullWidth",
         onClick: this.handleChange,
-        orientation
+        orientation,
+        textTransform
       });
     });
 

--- a/packages/riipen-ui/src/components/Tabs.test.jsx
+++ b/packages/riipen-ui/src/components/Tabs.test.jsx
@@ -223,6 +223,25 @@ describe("<Tabs>", () => {
     });
   });
 
+  describe("textTransform prop", () => {
+    it("sets textTransform in children nodes", () => {
+      const textTransform = "lowercase";
+      const child = <Tab label="Item one" value="one" />;
+
+      const wrapper = mount(<Tabs textTransform={textTransform}>{child}</Tabs>);
+
+      expect(wrapper.find("Tab").props().textTransform).toEqual("lowercase");
+    });
+
+    it("gives an error with invalid textTransform", () => {
+      const errors = jest.spyOn(console, "error").mockImplementation();
+
+      mount(<Tabs textTransform="invalid" />);
+
+      expect(errors).toHaveBeenCalled();
+    });
+  });
+
   describe("variant prop", () => {
     it("sets fullWidth to be true in children nodes when variant is fullWidth", () => {
       const variant = "fullWidth";

--- a/packages/riipen-ui/src/components/__snapshots__/Tab.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Tab.test.jsx.snap
@@ -11,6 +11,7 @@ exports[`<Tab> renders correct snapshot 1`] = `
     disabled={false}
     fullWidth={false}
     orientation="horizontal"
+    textTransform="uppercase"
     theme={
       Object {
         "breakpoints": Object {
@@ -262,7 +263,7 @@ exports[`<Tab> renders correct snapshot 1`] = `
     <div
       aria-disabled={false}
       aria-pressed={false}
-      className="jsx-3946002139 root breakpoint secondary horizontal"
+      className="jsx-275678284 root breakpoint secondary horizontal"
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -281,6 +282,7 @@ exports[`<Tab> renders correct snapshot 1`] = `
           400,
           "14px",
           "20px",
+          "uppercase",
           NaN,
           20,
           "#fafafa",
@@ -302,7 +304,7 @@ exports[`<Tab> renders correct snapshot 1`] = `
           12,
         ]
       }
-      id="2611317325"
+      id="1046851272"
     />
   </Tab>
 </Component>

--- a/packages/riipen-ui/src/components/__snapshots__/Tabs.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Tabs.test.jsx.snap
@@ -13,6 +13,7 @@ exports[`<Tabs> renders correct snapshot 1`] = `
     color="secondary"
     component="div"
     orientation="horizontal"
+    textTransform="uppercase"
     variant="standard"
   >
     <div


### PR DESCRIPTION
## Description
Add textTransform prop to tabs to allow for different casing types.

## Screenshots
![Screenshot 2022-01-25 at 09-55-50 Tabs Riipen UI](https://user-images.githubusercontent.com/10818279/151038357-83e6a75f-8bd7-4a98-a4f5-989086d30b99.png)

## Where to Start
src/components/Tab
src/components/Tabs
