### PR TITLE
Add letterSpacing prop

### DIFF
--- a/packages/riipen-ui-docs/src/pages/components/tabs/LetterSpacing.jsx
+++ b/packages/riipen-ui-docs/src/pages/components/tabs/LetterSpacing.jsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+import Tabs from "riipen-ui/components/Tabs";
+import Tab from "riipen-ui/components/Tab";
+
+export default function LetterSpacing() {
+  const style = {
+    backgroundColor: "#fff"
+  };
+
+  const [state, setState] = React.useState({
+    value: "one"
+  });
+
+  const handleChange = (e, value) => {
+    setState({ ...state, value });
+  };
+
+  return (
+    <div>
+      <div style={style}>
+        <Tabs
+          onChange={handleChange}
+          value={state.value}
+          variant="fullWidth"
+          letterSpacing={10}
+        >
+          <Tab label="Item one" value="one" />
+          <Tab label="Item two" value="two" />
+          <Tab label="Item three" value="three" />
+        </Tabs>
+      </div>
+    </div>
+  );
+}

--- a/packages/riipen-ui-docs/src/pages/components/tabs/tabs.md
+++ b/packages/riipen-ui-docs/src/pages/components/tabs/tabs.md
@@ -42,6 +42,12 @@ You can set the breakpoint to display the horizontal tab mobile styling with the
 
 {{"demo": "pages/components/tabs/Breakpoint.js"}}
 
+## Letter Spacing
+
+You can set the tab label letter spacing with the `letterSpacing` prop.
+
+{{"demo": "pages/components/tabs/LetterSpacing.js"}}
+
 ## Text Transform
 
 You can set the tab label casing with the `textTransform` prop.

--- a/packages/riipen-ui/src/components/Tab.jsx
+++ b/packages/riipen-ui/src/components/Tab.jsx
@@ -16,6 +16,7 @@ const Tab = props => {
     fullWidth,
     icon: Icon,
     label,
+    letterSpacing,
     onClick,
     orientation,
     textTransform,
@@ -108,7 +109,7 @@ const Tab = props => {
           font-family: ${theme.typography.fontFamily};
           font-weight: ${theme.typography.fontWeight.regular};
           font-size: ${theme.typography.body2.fontSize};
-          letter-spacing: 2px;
+          letter-spacing: ${letterSpacing}px;
           line-height: ${theme.typography.body2.lineHeight};
           text-decoration: none;
           text-transform: ${textTransform};
@@ -186,6 +187,7 @@ Tab.defaultProps = {
   color: "secondary",
   disabled: false,
   fullWidth: false,
+  letterSpacing: 2,
   orientation: "horizontal",
   textTransform: "uppercase"
 };
@@ -235,6 +237,11 @@ Tab.propTypes = {
    * The label element.
    */
   label: PropTypes.node,
+
+  /**
+   * Spacing to apply to letters. Is always 1px at screen sizes smaller `breakpoint` prop.
+   */
+  letterSpacing: PropTypes.number,
 
   /**
    * Callback fired when the tab is clicked.

--- a/packages/riipen-ui/src/components/Tab.test.jsx
+++ b/packages/riipen-ui/src/components/Tab.test.jsx
@@ -37,6 +37,7 @@ describe("<Tab>", () => {
       expect(wrapper.find("Tab").props().color).toEqual("secondary");
       expect(wrapper.find("Tab").props().disabled).toEqual(false);
       expect(wrapper.find("Tab").props().fullWidth).toEqual(false);
+      expect(wrapper.find("Tab").props().letterSpacing).toEqual(2);
       expect(wrapper.find("Tab").props().orientation).toEqual("horizontal");
       expect(wrapper.find("Tab").props().textTransform).toEqual("uppercase");
     });
@@ -374,6 +375,17 @@ describe("<Tab>", () => {
           .childAt(0)
           .hasClass("focusVisible")
       ).toBeFalsy();
+    });
+  });
+
+  describe("letterSpacing prop", () => {
+    it("gives an error when given an invalid letterSpacing", () => {
+      const errors = jest.spyOn(console, "error").mockImplementation();
+      const letterSpacing = "invalid";
+
+      mount(<Tab letterSpacing={letterSpacing} value />);
+
+      expect(errors).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/riipen-ui/src/components/Tabs.jsx
+++ b/packages/riipen-ui/src/components/Tabs.jsx
@@ -36,6 +36,11 @@ class Tabs extends React.Component {
     component: PropTypes.elementType,
 
     /**
+     * Spacing to apply to letters to the Tab.
+     */
+    letterSpacing: PropTypes.number,
+
+    /**
      * Callback fired when the value changes.
      *
      * @param {object} event The event source of the callback
@@ -97,6 +102,7 @@ class Tabs extends React.Component {
       classes,
       color,
       component: Component,
+      letterSpacing,
       orientation,
       textTransform,
       value,
@@ -115,6 +121,7 @@ class Tabs extends React.Component {
         breakpoint,
         color,
         fullWidth: variant === "fullWidth",
+        letterSpacing,
         onClick: this.handleChange,
         orientation,
         textTransform

--- a/packages/riipen-ui/src/components/Tabs.test.jsx
+++ b/packages/riipen-ui/src/components/Tabs.test.jsx
@@ -146,6 +146,25 @@ describe("<Tabs>", () => {
     });
   });
 
+  describe("letterSpacing prop", () => {
+    it("sets letterSpacing in children nodes", () => {
+      const letterSpacing = 5;
+      const child = <Tab label="Item one" value="one" />;
+
+      const wrapper = mount(<Tabs letterSpacing={letterSpacing}>{child}</Tabs>);
+
+      expect(wrapper.find("Tab").props().letterSpacing).toEqual(5);
+    });
+
+    it("gives an error with invalid letterSpacing", () => {
+      const errors = jest.spyOn(console, "error").mockImplementation();
+
+      mount(<Tabs letterSpacing="invalid" />);
+
+      expect(errors).toHaveBeenCalled();
+    });
+  });
+
   describe("onChange prop", () => {
     it("sets onClick prop of children nodes", () => {
       const child = <Tab label="Item one" value="one" />;

--- a/packages/riipen-ui/src/components/__snapshots__/Tab.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Tab.test.jsx.snap
@@ -10,6 +10,7 @@ exports[`<Tab> renders correct snapshot 1`] = `
     color="secondary"
     disabled={false}
     fullWidth={false}
+    letterSpacing={2}
     orientation="horizontal"
     textTransform="uppercase"
     theme={
@@ -281,6 +282,7 @@ exports[`<Tab> renders correct snapshot 1`] = `
           "Roboto, Helvetica, Arial, sans-serif",
           400,
           "14px",
+          2,
           "20px",
           "uppercase",
           NaN,
@@ -304,7 +306,7 @@ exports[`<Tab> renders correct snapshot 1`] = `
           12,
         ]
       }
-      id="1046851272"
+      id="2118809873"
     />
   </Tab>
 </Component>

--- a/packages/riipen-ui/src/components/__snapshots__/Tab.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Tab.test.jsx.snap
@@ -264,7 +264,7 @@ exports[`<Tab> renders correct snapshot 1`] = `
     <div
       aria-disabled={false}
       aria-pressed={false}
-      className="jsx-363881862 root breakpoint secondary horizontal"
+      className="jsx-4026516279 root breakpoint secondary horizontal"
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}


### PR DESCRIPTION
## Description
Add letterSpacing prop to tabs.  Reason behind this is that we use custom styling to set the letter spacing to smaller on our site, so might as well bake it into tabs to DRY it up.  I can provide examples where we use it if needed.

## Screenshots
![Screenshot 2022-01-27 at 11-16-45 Tabs Riipen UI](https://user-images.githubusercontent.com/10818279/151429045-881e2043-872f-4b99-8d03-28eba911ef72.png)

## Where to Start
src/components/Tab
src/components/Tabs