### PR TITLE
Update docs webpage whenever new version of UI kit is released

### DIFF
--- a/packages/riipen-ui/scripts/release.sh
+++ b/packages/riipen-ui/scripts/release.sh
@@ -2,6 +2,7 @@
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 SEMANTIC_VERSION=$1
+DOCS_BRANCH="docs"
 
 if [[ "$BRANCH" != "master" ]]; then
   echo "Must be on branch master to release"
@@ -13,6 +14,15 @@ if [[ $1 -eq 0 ]]; then
   echo "Usage: ./scripts/release.sh 0.4.xx"
   exit 1;
 fi
+
+# Update UI docs page first
+git checkout $DOCS_BRANCH
+git pull origin $DOCS_BRANCH
+git merge origin/master
+git push origin $DOCS_BRANCH
+
+# Switch back to master branch
+git checkout $BRANCH
 
 NPM_VERSION=$(npm version $SEMANTIC_VERSION)
 


### PR DESCRIPTION
## Description
Update the release script so that we can automatically deploy new changes to the docs webpage

## Notes
Discussion around this came out during the recent [retro](https://trello.com/c/uN2mOmcc/8-publish-docs-during-publish-script-for-ui-kit)

## Where to Start
`packages/riipen-ui/scripts/release.sh`