### PR TITLE
Allow tab to be prop type node

### DIFF
--- a/packages/riipen-ui/src/components/Tab.jsx
+++ b/packages/riipen-ui/src/components/Tab.jsx
@@ -75,7 +75,11 @@ const Tab = props => {
         onFocus={handleFocus}
         onBlur={handleBlur}
       >
-        {Icon && <Icon className={clsx("icon")} />}
+        {Icon && (
+          <span className={clsx("icon")}>
+            {typeof Icon === "function" ? <Icon /> : Icon}
+          </span>
+        )}
         {label && <div className={clsx("label")}>{label}</div>}
       </div>
       <style jsx>{`
@@ -102,7 +106,7 @@ const Tab = props => {
         }
 
         .icon {
-          margin-bottom: 1px;
+          display: flex;
         }
 
         .label {
@@ -231,7 +235,7 @@ Tab.propTypes = {
   /**
    * The icon element.
    */
-  icon: PropTypes.elementType,
+  icon: PropTypes.oneOfType([PropTypes.elementType, PropTypes.node]),
 
   /**
    * The label element.

--- a/packages/riipen-ui/src/components/Tab.test.jsx
+++ b/packages/riipen-ui/src/components/Tab.test.jsx
@@ -244,6 +244,12 @@ describe("<Tab>", () => {
           .hasClass("icon")
       ).toEqual(true);
     });
+
+    it("renders icon when icon is node", () => {
+      const wrapper = mount(<Tab icon={"bob"} value />);
+
+      expect(wrapper.text()).toEqual("bob");
+    });
   });
 
   describe("label prop", () => {

--- a/packages/riipen-ui/src/components/__snapshots__/Tab.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Tab.test.jsx.snap
@@ -264,7 +264,7 @@ exports[`<Tab> renders correct snapshot 1`] = `
     <div
       aria-disabled={false}
       aria-pressed={false}
-      className="jsx-4026516279 root breakpoint secondary horizontal"
+      className="jsx-563575015 root breakpoint secondary horizontal"
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -306,7 +306,7 @@ exports[`<Tab> renders correct snapshot 1`] = `
           12,
         ]
       }
-      id="2118809873"
+      id="575242985"
     />
   </Tab>
 </Component>


### PR DESCRIPTION
## Description
Update Tab to allow icons of type node.

## Where to Start
src/components/Tab