### PR TITLE
Improve tooltip arrow bottom position

### DIFF
--- a/packages/riipen-ui/src/components/Tooltip.jsx
+++ b/packages/riipen-ui/src/components/Tooltip.jsx
@@ -183,7 +183,9 @@ const Tooltip = ({
       .popover.bottom-right::after {
         border-bottom-color: var(--after-color);
         border-left: none;
+        border-width: ${theme.spacing(2)}px;
         left: 0;
+        margin-top: calc(${theme.spacing(-4)}px + 1px);
       }
 
       .popover.bottom-center::before {
@@ -212,6 +214,8 @@ const Tooltip = ({
       .popover.bottom-left::after {
         border-bottom-color: var(--after-color);
         border-right: none;
+        border-width: ${theme.spacing(2)}px;
+        margin-top: calc(${theme.spacing(-4)}px + 1px);
         right: 0;
       }
 

--- a/packages/riipen-ui/src/components/__snapshots__/Tooltip.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Tooltip.test.jsx.snap
@@ -35,7 +35,7 @@ exports[`<Tooltip> renders correct snapshot 1`] = `
         Array [
           "riipen",
           "riipen-tooltip",
-          "jsx-3467638454",
+          "jsx-755575304",
           "popover",
           "default",
           "bottom-center",
@@ -69,7 +69,7 @@ exports[`<Tooltip> renders correct snapshot 1`] = `
             "riipen-popover",
             "riipen",
             "riipen-tooltip",
-            "jsx-3467638454",
+            "jsx-755575304",
             "popover",
             "default",
             "bottom-center",
@@ -144,7 +144,11 @@ exports[`<Tooltip> renders correct snapshot 1`] = `
           12,
           -16,
           8,
+          -16,
           8,
+          8,
+          8,
+          -16,
           8,
           -16,
           8,
@@ -166,7 +170,7 @@ exports[`<Tooltip> renders correct snapshot 1`] = `
           8,
         ]
       }
-      id="4063941441"
+      id="918424231"
     />
   </Tooltip>
 </withClasses(Tooltip)>


### PR DESCRIPTION
## Description
Add border-width and calculated margin-top to Tooltip bottom arrow position to make it look better

## Notes
Is a small change but looks prettier

## Screenshots
Before:
![Screen Shot 2022-02-02 at 12 03 24 PM](https://user-images.githubusercontent.com/16536701/152202376-9d00e1cf-ab4b-4f8f-b86a-6557c32ea3ec.png)
![Screen Shot 2022-02-02 at 12 10 25 PM](https://user-images.githubusercontent.com/16536701/152202713-95d19546-70e6-4a93-81bb-5369e114e8d4.png)

After:
![Screen Shot 2022-02-02 at 12 03 16 PM](https://user-images.githubusercontent.com/16536701/152202385-326179fe-0e63-40e3-b61b-8a9dd7c8d514.png)
![Screen Shot 2022-02-02 at 12 09 50 PM](https://user-images.githubusercontent.com/16536701/152202634-a727d812-a827-4277-b61a-ddfaebc3eb3c.png)

## Where to Start
