### PR TITLE
[PLT-9035] aditional fixes to typography sizes on mobile

### DIFF
--- a/packages/riipen-ui/src/components/Tab.jsx
+++ b/packages/riipen-ui/src/components/Tab.jsx
@@ -174,10 +174,17 @@ const Tab = props => {
           }
 
           .breakpoint > * {
+            padding: ${theme.spacing(1)}px ${theme.spacing(3)}px;
+          }
+
+          .label {
             font-size: ${theme.typography.body2.mobile.fontSize};
             letter-spacing: 1px;
             line-height: ${theme.typography.body2.mobile.lineHeight};
-            padding: ${theme.spacing(1)}px ${theme.spacing(3)}px;
+          }
+
+          .vertical {
+            padding: ${theme.spacing(2)}px ${theme.spacing(5)}px;
           }
         }
       `}</style>

--- a/packages/riipen-ui/src/components/__snapshots__/Tab.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Tab.test.jsx.snap
@@ -264,7 +264,7 @@ exports[`<Tab> renders correct snapshot 1`] = `
     <div
       aria-disabled={false}
       aria-pressed={false}
-      className="jsx-2285103972 root breakpoint secondary horizontal"
+      className="jsx-1146669324 root breakpoint secondary horizontal"
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -300,13 +300,15 @@ exports[`<Tab> renders correct snapshot 1`] = `
           "#ddd",
           24,
           -4,
-          "12px",
-          "16px",
           4,
           12,
+          "12px",
+          "16px",
+          8,
+          20,
         ]
       }
-      id="575242985"
+      id="1274470273"
     />
   </Tab>
 </Component>


### PR DESCRIPTION
## Description
- Add Tab label mobile font size, applicable for horizontal and vertical tabs
- Update vertical Tabs padding to adjust to mobile res

## Notes

## Screenshots

## Where to Start
