### PR TITLE
[PLT-9469] Update circleci node docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ workflows:
 jobs:
   checkout:
     docker:
-      - image: circleci/node:16.13-bullseye
+      - image: cimg/node:16.13
         <<: *docker-auth
 
     steps:
@@ -96,7 +96,7 @@ jobs:
 
   lint:
     docker:
-      - image: circleci/node:16.13-bullseye
+      - image: cimg/node:16.13
         <<: *docker-auth
 
     steps:
@@ -110,7 +110,7 @@ jobs:
     resource_class: large
 
     docker:
-      - image: circleci/node:16.13-bullseye
+      - image: cimg/node:16.13
         <<: *docker-auth
 
     steps:
@@ -130,7 +130,7 @@ jobs:
     resource_class: large
 
     docker:
-      - image: circleci/node:16.13-bullseye
+      - image: cimg/node:16.13
         <<: *docker-auth
 
     steps:
@@ -147,7 +147,7 @@ jobs:
 
   coverage:
     docker:
-      - image: circleci/node:16.13-bullseye
+      - image: cimg/node:16.13
         <<: *docker-auth
 
     environment:


### PR DESCRIPTION
## Description

Update circleci node docker image to non deprecated version

## Notes

## Screenshots

## Where to Start
