### PR TITLE
[PLT-9470] Adjusted checkbox weight and alignment

### DIFF
--- a/packages/riipen-ui/src/components/Checkbox.jsx
+++ b/packages/riipen-ui/src/components/Checkbox.jsx
@@ -145,9 +145,9 @@ const Checkbox = props => {
         /* Style the checkmark/indicator */
         label .checkmark:after {
           border: solid white;
-          border-width: 0 3px 3px 0;
-          height: 10px;
-          left: 6px;
+          border-width: 0 2px 2px 0;
+          height: 11px;
+          left: 7px;
           top: 2px;
           transform: rotate(45deg);
           width: 5px;

--- a/packages/riipen-ui/src/components/__snapshots__/Checkbox.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Checkbox.test.jsx.snap
@@ -257,10 +257,10 @@ exports[`<Checkbox> renders correct snapshot 1`] = `
     }
   >
     <div
-      className="jsx-4032343330 "
+      className="jsx-3779997386 "
     >
       <label
-        className="jsx-4032343330"
+        className="jsx-3779997386"
       >
         <withClasses(Typography)>
           <Typography
@@ -375,7 +375,7 @@ exports[`<Checkbox> renders correct snapshot 1`] = `
         </withClasses(Typography)>
         <input
           checked={false}
-          className="jsx-4032343330 checkbox"
+          className="jsx-3779997386 checkbox"
           disabled={false}
           onBlur={[Function]}
           onFocus={[Function]}
@@ -384,7 +384,7 @@ exports[`<Checkbox> renders correct snapshot 1`] = `
           type="checkbox"
         />
         <span
-          className="jsx-4032343330 checkmark"
+          className="jsx-3779997386 checkmark"
         />
       </label>
       <JSXStyle
@@ -403,7 +403,7 @@ exports[`<Checkbox> renders correct snapshot 1`] = `
             8,
           ]
         }
-        id="3340623778"
+        id="1863449125"
       />
     </div>
   </Checkbox>


### PR DESCRIPTION
## Description

Adjusted checkboxes to be thinner and centre aligned with text

## Notes

## Screenshots

Before:
![11408f33-8d65-40fd-9453-a6abeda817c6](https://user-images.githubusercontent.com/47232534/159048368-bddbc553-de6b-4295-9429-67fc52d52885.png)

After:
![062c2d6d-a643-4b38-983f-3fcc26b55a3f](https://user-images.githubusercontent.com/47232534/159048404-a60fb905-d376-40e8-95d3-3440a2f46ec6.png)


## Where to Start
