### PR TITLE
Update lg breakpoint

### DIFF
--- a/packages/riipen-ui/src/components/__snapshots__/Button.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Button.test.jsx.snap
@@ -12,7 +12,7 @@ exports[`<Button> renders correct snapshot 1`] = `
     theme={
       Object {
         "breakpoints": Object {
-          "lg": 1440,
+          "lg": 1280,
           "md": 960,
           "sm": 480,
           "xl": 1920,

--- a/packages/riipen-ui/src/components/__snapshots__/ButtonIcon.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/ButtonIcon.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`<ButtonIcon> renders correct snapshot 1`] = `
     theme={
       Object {
         "breakpoints": Object {
-          "lg": 1440,
+          "lg": 1280,
           "md": 960,
           "sm": 480,
           "xl": 1920,
@@ -263,7 +263,7 @@ exports[`<ButtonIcon> renders correct snapshot 1`] = `
       theme={
         Object {
           "breakpoints": Object {
-            "lg": 1440,
+            "lg": 1280,
             "md": 960,
             "sm": 480,
             "xl": 1920,

--- a/packages/riipen-ui/src/components/__snapshots__/Checkbox.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Checkbox.test.jsx.snap
@@ -12,7 +12,7 @@ exports[`<Checkbox> renders correct snapshot 1`] = `
     theme={
       Object {
         "breakpoints": Object {
-          "lg": 1440,
+          "lg": 1280,
           "md": 960,
           "sm": 480,
           "xl": 1920,

--- a/packages/riipen-ui/src/components/__snapshots__/Chip.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Chip.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`<Chip> renders correct snapshot 1`] = `
     theme={
       Object {
         "breakpoints": Object {
-          "lg": 1440,
+          "lg": 1280,
           "md": 960,
           "sm": 480,
           "xl": 1920,
@@ -265,7 +265,7 @@ exports[`<Chip> renders correct snapshot 1`] = `
       theme={
         Object {
           "breakpoints": Object {
-            "lg": 1440,
+            "lg": 1280,
             "md": 960,
             "sm": 480,
             "xl": 1920,

--- a/packages/riipen-ui/src/components/__snapshots__/Container.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Container.test.jsx.snap
@@ -12,14 +12,14 @@ exports[`<Container> renders correct snapshot 1`] = `
     maxWidth="lg"
   >
     <div
-      className="jsx-140395240 root riipen riipen-container"
+      className="jsx-1579358696 root riipen riipen-container"
     >
       <JSXStyle
         dynamic={
           Array [
-            "1440px",
+            "1280px",
             24,
-            1440,
+            1280,
             20,
             960,
             12,

--- a/packages/riipen-ui/src/components/__snapshots__/Hidden.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Hidden.test.jsx.snap
@@ -15,7 +15,7 @@ exports[`<Hidden> renders correct snapshot 1`] = `
     size="sm"
   >
     <div
-      className="jsx-3239942441 sm-down"
+      className="jsx-3216341865 sm-down"
     />
     <JSXStyle
       dynamic={
@@ -26,8 +26,8 @@ exports[`<Hidden> renders correct snapshot 1`] = `
           480,
           960,
           960,
-          1440,
-          1440,
+          1280,
+          1280,
           1920,
           1920,
         ]

--- a/packages/riipen-ui/src/components/__snapshots__/Input.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Input.test.jsx.snap
@@ -9,7 +9,7 @@ exports[`<Input> renders correct snapshot 1`] = `
     theme={
       Object {
         "breakpoints": Object {
-          "lg": 1440,
+          "lg": 1280,
           "md": 960,
           "sm": 480,
           "xl": 1920,

--- a/packages/riipen-ui/src/components/__snapshots__/InputHint.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/InputHint.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`<InputHint> renders correct snapshot 1`] = `
     theme={
       Object {
         "breakpoints": Object {
-          "lg": 1440,
+          "lg": 1280,
           "md": 960,
           "sm": 480,
           "xl": 1920,
@@ -261,7 +261,7 @@ exports[`<InputHint> renders correct snapshot 1`] = `
       theme={
         Object {
           "breakpoints": Object {
-            "lg": 1440,
+            "lg": 1280,
             "md": 960,
             "sm": 480,
             "xl": 1920,

--- a/packages/riipen-ui/src/components/__snapshots__/InputLabel.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/InputLabel.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`<InputLabel> renders correct snapshot 1`] = `
     theme={
       Object {
         "breakpoints": Object {
-          "lg": 1440,
+          "lg": 1280,
           "md": 960,
           "sm": 480,
           "xl": 1920,
@@ -263,7 +263,7 @@ exports[`<InputLabel> renders correct snapshot 1`] = `
       theme={
         Object {
           "breakpoints": Object {
-            "lg": 1440,
+            "lg": 1280,
             "md": 960,
             "sm": 480,
             "xl": 1920,

--- a/packages/riipen-ui/src/components/__snapshots__/Link.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Link.test.jsx.snap
@@ -12,7 +12,7 @@ exports[`<Link> renders correct snapshot 1`] = `
     theme={
       Object {
         "breakpoints": Object {
-          "lg": 1440,
+          "lg": 1280,
           "md": 960,
           "sm": 480,
           "xl": 1920,

--- a/packages/riipen-ui/src/components/__snapshots__/ListItem.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/ListItem.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`<ListItem> renders correct snapshot 1`] = `
     theme={
       Object {
         "breakpoints": Object {
-          "lg": 1440,
+          "lg": 1280,
           "md": 960,
           "sm": 480,
           "xl": 1920,
@@ -261,7 +261,7 @@ exports[`<ListItem> renders correct snapshot 1`] = `
       theme={
         Object {
           "breakpoints": Object {
-            "lg": 1440,
+            "lg": 1280,
             "md": 960,
             "sm": 480,
             "xl": 1920,

--- a/packages/riipen-ui/src/components/__snapshots__/RadioButtonGroup.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/RadioButtonGroup.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
     theme={
       Object {
         "breakpoints": Object {
-          "lg": 1440,
+          "lg": 1280,
           "md": 960,
           "sm": 480,
           "xl": 1920,
@@ -260,7 +260,7 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
       theme={
         Object {
           "breakpoints": Object {
-            "lg": 1440,
+            "lg": 1280,
             "md": 960,
             "sm": 480,
             "xl": 1920,

--- a/packages/riipen-ui/src/components/__snapshots__/Tab.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/Tab.test.jsx.snap
@@ -16,7 +16,7 @@ exports[`<Tab> renders correct snapshot 1`] = `
     theme={
       Object {
         "breakpoints": Object {
-          "lg": 1440,
+          "lg": 1280,
           "md": 960,
           "sm": 480,
           "xl": 1920,

--- a/packages/riipen-ui/src/components/__snapshots__/VerticalDivider.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/VerticalDivider.test.jsx.snap
@@ -8,7 +8,7 @@ exports[`<VerticalDivider> renders correct snapshot 1`] = `
     theme={
       Object {
         "breakpoints": Object {
-          "lg": 1440,
+          "lg": 1280,
           "md": 960,
           "sm": 480,
           "xl": 1920,

--- a/packages/riipen-ui/src/themes/default.js
+++ b/packages/riipen-ui/src/themes/default.js
@@ -3,7 +3,7 @@ export default {
     xs: 320,
     sm: 480,
     md: 960,
-    lg: 1440,
+    lg: 1280,
     xl: 1920
   },
   palette: {


### PR DESCRIPTION
## Description
Update lg breakpoint to be 1280 px.  Components that are currently using lg breakpoint are Container, Grid, and Hidden.

## Notes
Will need to do extensive testing to see if other things need to be updated.

## Where to Start
packages/riipen-ui/src/themes/default.js