### PR TITLE
Add id prop to RadioButton

### DIFF
--- a/packages/riipen-ui/src/components/RadioButton.jsx
+++ b/packages/riipen-ui/src/components/RadioButton.jsx
@@ -13,11 +13,11 @@ const RadioButton = ({
   classes,
   color,
   disabled,
-  id,
   label,
   prefix,
   size,
   suffix,
+  wrapperProps,
   ...other
 }) => {
   const theme = React.useContext(ThemeContext);
@@ -41,7 +41,7 @@ const RadioButton = ({
         "root",
         size
       )}
-      id={id}
+      {...wrapperProps}
     >
       <label className={clsx(checked && "checked", disabled && "disabled")}>
         <input checked={checked} disabled={disabled} type="radio" {...other} />
@@ -189,11 +189,6 @@ RadioButton.propTypes = {
   disabled: PropTypes.bool,
 
   /**
-   * An ID to set on the wrapper div of this component.
-   */
-  id: PropTypes.string,
-
-  /**
    * Label text to display for the radio.
    */
   label: PropTypes.node,
@@ -211,12 +206,18 @@ RadioButton.propTypes = {
   /**
    * The component to render after the label text.
    */
-  suffix: PropTypes.node
+  suffix: PropTypes.node,
+
+  /**
+   * Props to apply to div wrapper.
+   */
+  wrapperProps: PropTypes.object
 };
 
 RadioButton.defaultProps = {
   size: "medium",
-  color: "default"
+  color: "default",
+  wrapperProps: {}
 };
 
 RadioButton.displayName = "RadioButton";

--- a/packages/riipen-ui/src/components/RadioButton.jsx
+++ b/packages/riipen-ui/src/components/RadioButton.jsx
@@ -13,6 +13,7 @@ const RadioButton = ({
   classes,
   color,
   disabled,
+  id,
   label,
   prefix,
   size,
@@ -24,7 +25,7 @@ const RadioButton = ({
   let typographyVariant;
   if (size === "medium") {
     typographyVariant = "body2";
-  } else if(size === "small"){
+  } else if (size === "small") {
     typographyVariant = "body3";
   } else if (size === "large") {
     typographyVariant = "h5";
@@ -40,6 +41,7 @@ const RadioButton = ({
         "root",
         size
       )}
+      id={id}
     >
       <label className={clsx(checked && "checked", disabled && "disabled")}>
         <input checked={checked} disabled={disabled} type="radio" {...other} />
@@ -185,6 +187,11 @@ RadioButton.propTypes = {
    * If `true`, the radio will be disabled.
    */
   disabled: PropTypes.bool,
+
+  /**
+   * An ID to set on the wrapper div of this component.
+   */
+  id: PropTypes.string,
 
   /**
    * Label text to display for the radio.

--- a/packages/riipen-ui/src/components/RadioButton.test.jsx
+++ b/packages/riipen-ui/src/components/RadioButton.test.jsx
@@ -131,6 +131,21 @@ describe("<RadioButton>", () => {
     expect(wrapper.find("input").props().disabled).toEqual(disabled);
   });
 
+  describe("id prop", () => {
+    it("sets the id", () => {
+      const id = "pikachu";
+
+      const wrapper = mount(<RadioButton id={id} />);
+
+      expect(
+        wrapper
+          .find("RadioButton")
+          .childAt(0)
+          .prop("id")
+      ).toEqual(id);
+    });
+  });
+
   describe("label prop", () => {
     it("sets custom label", () => {
       const label = "Test";

--- a/packages/riipen-ui/src/components/RadioButton.test.jsx
+++ b/packages/riipen-ui/src/components/RadioButton.test.jsx
@@ -131,21 +131,6 @@ describe("<RadioButton>", () => {
     expect(wrapper.find("input").props().disabled).toEqual(disabled);
   });
 
-  describe("id prop", () => {
-    it("sets the id", () => {
-      const id = "pikachu";
-
-      const wrapper = mount(<RadioButton id={id} />);
-
-      expect(
-        wrapper
-          .find("RadioButton")
-          .childAt(0)
-          .prop("id")
-      ).toEqual(id);
-    });
-  });
-
   describe("label prop", () => {
     it("sets custom label", () => {
       const label = "Test";
@@ -204,6 +189,21 @@ describe("<RadioButton>", () => {
           .childAt(0)
           .hasClass(size)
       ).toEqual(true);
+    });
+  });
+
+  describe("wrapperProps prop", () => {
+    it("passes given wrapperProps attributes", () => {
+      const wrapperProps = { id: "yo" };
+
+      const wrapper = mount(<RadioButton wrapperProps={wrapperProps} />);
+
+      expect(
+        wrapper
+          .find("div")
+          .at(0)
+          .props().id
+      ).toEqual("yo");
     });
   });
 });

--- a/packages/riipen-ui/src/components/__snapshots__/RadioButton.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/RadioButton.test.jsx.snap
@@ -11,6 +11,7 @@ exports[`<RadioButton> renders correct snapshot 1`] = `
     }
     color="default"
     size="medium"
+    wrapperProps={Object {}}
   >
     <div
       className="jsx-2262169576 riipen riipen-radiobutton default root medium"

--- a/packages/riipen-ui/src/components/__snapshots__/RadioButtonGroup.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/RadioButtonGroup.test.jsx.snap
@@ -535,6 +535,7 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
               color="default"
               onChange={[Function]}
               size="medium"
+              wrapperProps={Object {}}
             >
               <div
                 className="jsx-2262169576 riipen riipen-radiobutton jsx-1527667869 radioButton default checked root medium"


### PR DESCRIPTION
## Description
Add wrapperProps to RadioButton so we can pass props to the wrapper div.  Thought about having `inputProps` instead but it would be a breaking change for radio button.
