### PR TITLE
Add full width option to radio buttons

### DIFF
--- a/packages/riipen-ui/src/components/RadioButtonGroup.jsx
+++ b/packages/riipen-ui/src/components/RadioButtonGroup.jsx
@@ -14,6 +14,7 @@ import Typography from "./Typography";
 const RadioButtonGroup = ({
   children,
   error,
+  fullWidth,
   hint,
   id,
   label,
@@ -37,12 +38,20 @@ const RadioButtonGroup = ({
       border-bottom-right-radius: ${theme.shape.borderRadius.md};
     }
 
-    .connected..radioButtons .radioButton:not(:first-child) {
+    .connected.radioButtons .radioButton:not(:first-child) {
       border-left-color: transparent;
     }
 
     .connected.radioButtons .radioButton:not(:first-child .checked):hover {
       border-left-color: inherit;
+    }
+
+    .fullWidth {
+      display: flex;
+    }
+
+    .fullWidth > * {
+      flex: 1 1 ${100 / (React.Children.count || 1)}%;
     }
 
     .separate.radioButtons .radioButton {
@@ -91,7 +100,14 @@ const RadioButtonGroup = ({
           </InputLabel>
         )}
 
-        <div className={clsx("radioButtons", variant, linkedStyles.className)}>
+        <div
+          className={clsx(
+            "radioButtons",
+            fullWidth && "fullWidth",
+            variant,
+            linkedStyles.className
+          )}
+        >
           {childrenWithProps}
         </div>
 
@@ -140,6 +156,11 @@ RadioButtonGroup.propTypes = {
    * An ID to set on this component.
    */
   id: PropTypes.string,
+
+  /**
+   * If `true`, will make the radio button group grow to use all the available space.
+   */
+  fullWidth: PropTypes.bool,
 
   /**
    * Label text to display for the input.

--- a/packages/riipen-ui/src/components/RadioButtonGroup.jsx
+++ b/packages/riipen-ui/src/components/RadioButtonGroup.jsx
@@ -46,12 +46,16 @@ const RadioButtonGroup = ({
       border-left-color: inherit;
     }
 
-    .fullWidth {
+    fieldset.fullWidth {
+      width: 100%;
+    }
+
+    div.fullWidth {
       display: flex;
     }
 
-    .fullWidth > * {
-      flex: 1 1 ${100 / (React.Children.count || 1)}%;
+    div.fullWidth > * {
+      flex: 1 1 ${100 / (React.Children.count(children) || 1)}%;
     }
 
     .separate.radioButtons .radioButton {
@@ -88,7 +92,10 @@ const RadioButtonGroup = ({
 
   return (
     <>
-      <fieldset id={id}>
+      <fieldset
+        className={clsx(fullWidth && "fullWidth", linkedStyles.className)}
+        id={id}
+      >
         {(label || hint) && (
           <InputLabel
             hint={hint}

--- a/packages/riipen-ui/src/components/RadioButtonGroup.test.jsx
+++ b/packages/riipen-ui/src/components/RadioButtonGroup.test.jsx
@@ -57,6 +57,23 @@ describe("<RadioButtonGroup>", () => {
     });
   });
 
+  describe("fullWidth prop", () => {
+    it("has correct classes", () => {
+      const child = <RadioButton id="one" />;
+
+      const wrapper = mount(
+        <RadioButtonGroup fullWidth>{child}</RadioButtonGroup>
+      );
+
+      expect(
+        wrapper
+          .find("fieldset")
+          .childAt(0)
+          .hasClass("fullWidth")
+      ).toBeTruthy();
+    });
+  });
+
   describe("hint prop", () => {
     it("renders InputLabel when hint is provided", () => {
       const hint = "it's a hint";

--- a/packages/riipen-ui/src/components/__snapshots__/RadioButtonGroup.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/RadioButtonGroup.test.jsx.snap
@@ -506,16 +506,16 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
       variant="connected"
     >
       <fieldset
-        className="jsx-3241897731"
+        className="jsx-3241897731 jsx-849752549"
       >
         <div
-          className="jsx-3241897731 radioButtons connected jsx-500097170"
+          className="jsx-3241897731 radioButtons connected jsx-849752549"
         >
           <withClasses(RadioButton)
             checked={true}
             classes={
               Array [
-                "jsx-500097170",
+                "jsx-849752549",
                 "radioButton",
               ]
             }
@@ -528,7 +528,7 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
                 Array [
                   "riipen",
                   "riipen-radiobutton",
-                  "jsx-500097170",
+                  "jsx-849752549",
                   "radioButton",
                 ]
               }
@@ -538,7 +538,7 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
               wrapperProps={Object {}}
             >
               <div
-                className="jsx-2262169576 riipen riipen-radiobutton jsx-500097170 radioButton default checked root medium"
+                className="jsx-2262169576 riipen riipen-radiobutton jsx-849752549 radioButton default checked root medium"
               >
                 <label
                   className="jsx-2262169576 checked"
@@ -716,12 +716,12 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
             "4px",
             "4px",
             "4px",
-            NaN,
+            100,
             "4px",
             16,
           ]
         }
-        id="1038292939"
+        id="1823270956"
       />
       <JSXStyle
         id="3241897731"

--- a/packages/riipen-ui/src/components/__snapshots__/RadioButtonGroup.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/RadioButtonGroup.test.jsx.snap
@@ -509,13 +509,13 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
         className="jsx-3241897731"
       >
         <div
-          className="jsx-3241897731 radioButtons connected jsx-1527667869"
+          className="jsx-3241897731 radioButtons connected jsx-500097170"
         >
           <withClasses(RadioButton)
             checked={true}
             classes={
               Array [
-                "jsx-1527667869",
+                "jsx-500097170",
                 "radioButton",
               ]
             }
@@ -528,7 +528,7 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
                 Array [
                   "riipen",
                   "riipen-radiobutton",
-                  "jsx-1527667869",
+                  "jsx-500097170",
                   "radioButton",
                 ]
               }
@@ -538,7 +538,7 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
               wrapperProps={Object {}}
             >
               <div
-                className="jsx-2262169576 riipen riipen-radiobutton jsx-1527667869 radioButton default checked root medium"
+                className="jsx-2262169576 riipen riipen-radiobutton jsx-500097170 radioButton default checked root medium"
               >
                 <label
                   className="jsx-2262169576 checked"
@@ -716,11 +716,12 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
             "4px",
             "4px",
             "4px",
+            NaN,
             "4px",
             16,
           ]
         }
-        id="4053215710"
+        id="1038292939"
       />
       <JSXStyle
         id="3241897731"


### PR DESCRIPTION
## Description
Add `fullWidth` prop to radio button group to enable to buttons to stretch across the full div.

## Screenshots
![Screenshot 2022-05-17 at 11-57-29 Messages](https://user-images.githubusercontent.com/10818279/168889646-1fa9a774-5a1f-48d0-b335-6db4e09d64a0.png)

## Where to Start
src/components/RadioButtonGroup.jsx