### PR TITLE
Pass through fullWidth to RadioButton to remove min width on label

### DIFF
--- a/packages/riipen-ui/src/components/RadioButton.jsx
+++ b/packages/riipen-ui/src/components/RadioButton.jsx
@@ -13,6 +13,7 @@ const RadioButton = ({
   classes,
   color,
   disabled,
+  fullWidth,
   label,
   prefix,
   size,
@@ -87,19 +88,19 @@ const RadioButton = ({
         /* Sizes */
 
         .small label {
-          min-width: 100px;
+          min-width: ${fullWidth ? "100%" : "100px"};
           padding: 4px;
           width: 100%;
         }
 
         .medium label {
-          min-width: 150px;
+          min-width: ${fullWidth ? "100%" : "150px"};
           padding: 6px 12px;
           width: 100%;
         }
 
         .large label {
-          min-width: 200px;
+          min-width: ${fullWidth ? "100%" : "200px"};
           padding: 10px;
           width: 100%;
         }
@@ -187,6 +188,11 @@ RadioButton.propTypes = {
    * If `true`, the radio will be disabled.
    */
   disabled: PropTypes.bool,
+
+  /**
+   * If `true`, will make the radio button grow to use all the available space.
+   */
+  fullWidth: PropTypes.bool,
 
   /**
    * Label text to display for the radio.

--- a/packages/riipen-ui/src/components/RadioButtonGroup.jsx
+++ b/packages/riipen-ui/src/components/RadioButtonGroup.jsx
@@ -79,6 +79,7 @@ const RadioButtonGroup = ({
       child &&
       React.cloneElement(child, {
         checked: value === child.props.value,
+        fullWidth,
         onChange: handleChange,
         ...other,
         ...child.props,

--- a/packages/riipen-ui/src/components/RadioButtonGroup.test.jsx
+++ b/packages/riipen-ui/src/components/RadioButtonGroup.test.jsx
@@ -72,6 +72,16 @@ describe("<RadioButtonGroup>", () => {
           .hasClass("fullWidth")
       ).toBeTruthy();
     });
+
+    it("passes through fullWidth to children", () => {
+      const child = <RadioButton id="one" />;
+
+      const wrapper = mount(
+        <RadioButtonGroup fullWidth>{child}</RadioButtonGroup>
+      );
+
+      expect(wrapper.find("RadioButton").prop("fullWidth")).toBeTruthy();
+    });
   });
 
   describe("hint prop", () => {

--- a/packages/riipen-ui/src/components/Typography.jsx
+++ b/packages/riipen-ui/src/components/Typography.jsx
@@ -167,7 +167,7 @@ class Typography extends React.Component {
       display,
       fontWeight,
       gutter ? "gutter" : null,
-      letterSpacing ? 'letter-spacing' : null,
+      letterSpacing ? "letter-spacing" : null,
       mobileBreakpoint ? "mobile" : null,
       variant,
       `align-${textAlign}`,

--- a/packages/riipen-ui/src/components/__snapshots__/RadioButton.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/RadioButton.test.jsx.snap
@@ -14,13 +14,13 @@ exports[`<RadioButton> renders correct snapshot 1`] = `
     wrapperProps={Object {}}
   >
     <div
-      className="jsx-2262169576 riipen riipen-radiobutton default root medium"
+      className="jsx-3721005054 riipen riipen-radiobutton default root medium"
     >
       <label
-        className="jsx-2262169576 "
+        className="jsx-3721005054 "
       >
         <input
-          className="jsx-2262169576 "
+          className="jsx-3721005054 "
           type="radio"
         />
         <withClasses(Typography)
@@ -48,7 +48,7 @@ exports[`<RadioButton> renders correct snapshot 1`] = `
               className="jsx-2216482402 root color-inherit initial mobile body2 align-inherit transform-inherit riipen riipen-typography"
             >
               <span
-                className="jsx-2262169576 content"
+                className="jsx-3721005054 content"
               />
             </span>
             <JSXStyle
@@ -149,6 +149,9 @@ exports[`<RadioButton> renders correct snapshot 1`] = `
           Array [
             4,
             "#dddddd",
+            "100px",
+            "150px",
+            "200px",
             "#dddddd",
             "#747474",
             "#747474",
@@ -176,7 +179,7 @@ exports[`<RadioButton> renders correct snapshot 1`] = `
             "#eeeeee",
           ]
         }
-        id="10583402"
+        id="4294560361"
       />
     </div>
   </RadioButton>

--- a/packages/riipen-ui/src/components/__snapshots__/RadioButtonGroup.test.jsx.snap
+++ b/packages/riipen-ui/src/components/__snapshots__/RadioButtonGroup.test.jsx.snap
@@ -538,14 +538,14 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
               wrapperProps={Object {}}
             >
               <div
-                className="jsx-2262169576 riipen riipen-radiobutton jsx-849752549 radioButton default checked root medium"
+                className="jsx-3721005054 riipen riipen-radiobutton jsx-849752549 radioButton default checked root medium"
               >
                 <label
-                  className="jsx-2262169576 checked"
+                  className="jsx-3721005054 checked"
                 >
                   <input
                     checked={true}
-                    className="jsx-2262169576 "
+                    className="jsx-3721005054 "
                     onChange={[Function]}
                     type="radio"
                   />
@@ -574,7 +574,7 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
                         className="jsx-2216482402 root color-inherit initial mobile body2 align-inherit transform-inherit riipen riipen-typography"
                       >
                         <span
-                          className="jsx-2262169576 content"
+                          className="jsx-3721005054 content"
                         />
                       </span>
                       <JSXStyle
@@ -675,6 +675,9 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
                     Array [
                       4,
                       "#dddddd",
+                      "100px",
+                      "150px",
+                      "200px",
                       "#dddddd",
                       "#747474",
                       "#747474",
@@ -702,7 +705,7 @@ exports[`<RadioButtonGroup> renders correct snapshot 1`] = `
                       "#eeeeee",
                     ]
                   }
-                  id="10583402"
+                  id="4294560361"
                 />
               </div>
             </RadioButton>


### PR DESCRIPTION
## Description
Part 2 to https://github.com/riipen/ui/pull/279
Pass `fullWidth` through to RadioButton so that radio button option labels are not constrained by either current `min-width` styling.

## Where to Start
src/components/RadioButton
src/components/RadioButtonGroup