### PR TITLE
Focus editor if autoFocus changes

### DIFF
--- a/packages/riipen-ui/src/components/Editor.jsx
+++ b/packages/riipen-ui/src/components/Editor.jsx
@@ -160,6 +160,14 @@ class Editor extends React.Component {
     this.onChange(editorState, false);
   }
 
+  componentDidUpdate(prevProps) {
+    const { autoFocus } = this.props;
+
+    if (autoFocus && prevProps.autoFocus !== autoFocus) {
+      this.forceFocus();
+    }
+  }
+
   onChange = (editorState, propagate = true) => {
     this.setState({ editorState }, () => {
       const html = this.getHtml();


### PR DESCRIPTION
## Description
Add `componentDidUpdate` for `autoFocus` prop to force focus on editor if the prop changes.

## Where to Start
src/components/Editor.jsx
